### PR TITLE
[Refactor] 저장공간을 위한 캐시정책을 추가

### DIFF
--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/ASCacheManager.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/ASCacheManager.swift
@@ -1,7 +1,7 @@
 import ASCacheKitProtocol
 import Foundation
 
-public struct ASCacheManager: CacheManagerProtocol, Sendable {
+public final class ASCacheManager: CacheManagerProtocol, Sendable {
     public let memoryCache: MemoryCacheManagerProtocol
     public let diskCache: DiskCacheManagerProtocol
 

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
@@ -4,7 +4,8 @@ import ASCacheKitProtocol
 final class DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
     private let fileManager = FileManager.default
     let cacheDirectory: URL
-
+    let maxSize = 350 * 1024 * 1024 // 350MB
+    
     init() {
         let cachesDirectory = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
         cacheDirectory = cachesDirectory.appendingPathComponent("MediaDiskCache")
@@ -16,22 +17,61 @@ final class DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
             try? fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true, attributes: nil)
         }
     }
-
+    
     func getData(forKey key: String) -> Data? {
         let fileURL = cacheDirectory.appendingPathComponent(key.sha256)
+        try? fileManager.setAttributes([.modificationDate : Date.now], ofItemAtPath: fileURL.path)
         return try? Data(contentsOf: fileURL)
     }
-
+    
     func saveData(_ data: Data, forKey key: String) {
         let fileURL = cacheDirectory.appendingPathComponent(key.sha256)
         try? data.write(to: fileURL)
+        optimizeCache()
     }
-
+    
     func clearCache() {
         if let files = try? fileManager.contentsOfDirectory(at: cacheDirectory, includingPropertiesForKeys: nil) {
             for fileURL in files {
                 try? fileManager.removeItem(at: fileURL)
             }
         }
+    }
+    
+    /// 캐시를 최적화하는 메서드
+    /// comment
+    ///
+    /// 설정해둔 max 용량보다 크면 가장 사용한지 오래된 캐시를 지웁니다.
+    private func optimizeCache() {
+        let (currentSize, totalFiles) = calculateTotalCache()
+        guard currentSize > maxSize else { return }
+        
+        let sortedFiles = totalFiles.sorted {
+            let date1 = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date.distantPast
+            let date2 = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date.distantPast
+            return date1 < date2
+        }
+        
+        var remainingSize = currentSize
+        for fileURL in sortedFiles {
+            guard remainingSize > maxSize else { break }
+            
+            let fileSize = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            try? fileManager.removeItem(at: fileURL)
+            remainingSize -= fileSize
+        }
+    }
+    
+    private func calculateTotalCache() -> (size: Int, files: [URL]) {
+        guard let totalFiles = try? fileManager.contentsOfDirectory(
+            at: cacheDirectory,
+            includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey]) else { return (0, []) }
+        
+        let totalSize = totalFiles.reduce(0) { sum, fileURL in
+            let fileSize = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize
+            return sum + (fileSize ?? 0)
+        }
+        
+        return (size: totalSize, files: totalFiles)
     }
 }

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ASCacheKitProtocol
 
-struct DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
+final class DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
     private let fileManager = FileManager.default
     let cacheDirectory: URL
 

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/MemoryCache.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/MemoryCache.swift
@@ -1,7 +1,7 @@
 import Foundation
 import ASCacheKitProtocol
 
-struct MemoryCacheManager: @unchecked Sendable, MemoryCacheManagerProtocol {
+final class MemoryCacheManager: @unchecked Sendable, MemoryCacheManagerProtocol {
     private let cache = NSCache<NSString, AnyObject>()
 
     func getObject(forKey key: String) -> AnyObject? {

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/MemoryCache.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/MemoryCache.swift
@@ -3,6 +3,12 @@ import ASCacheKitProtocol
 
 final class MemoryCacheManager: @unchecked Sendable, MemoryCacheManagerProtocol {
     private let cache = NSCache<NSString, AnyObject>()
+    
+    init() {
+        let totalMemory = ProcessInfo.processInfo.physicalMemory
+        let percentage = 10
+        cache.totalCostLimit = Int(totalMemory) * percentage / 100
+    }
 
     func getObject(forKey key: String) -> AnyObject? {
         return cache.object(forKey: key.sha256 as NSString)

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/HummingResultRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/HummingResultRepository.swift
@@ -128,14 +128,4 @@ public final class LocalHummingResultRepository: HummingResultRepositoryProtocol
 
         return submit ?? Answer.answerStub1
     }
-    
-    public func getRecordData(url: URL) async -> Data? {
-        do {
-            guard let endpoint = ResourceEndpoint(url: url) else { return nil }
-            let data = try await self.networkManager.sendRequest(to: endpoint, type: .json, body: nil, option: .both)
-            return data
-        } catch {
-            return nil
-        }
-    }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Secret.xcconfig
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Resources/Secret.xcconfig
@@ -1,1 +1,0 @@
-SERVER_URL = 비밀


### PR DESCRIPTION
## 관련 이슈

- #2 

## 완료 및 수정 내역

 - [관련 wiki](https://github.com/boostcampwm-2024/refactor-ios11-alsongDalsong/wiki/%EC%BA%90%EC%8B%9C-%EB%A9%94%EB%AA%A8%EB%A6%AC-%EA%B0%9C%EC%84%A0) 
- [x] 캐시 삭제로직 추가

## 리뷰 노트
wiki에 자세한 내용을 작성해 두었습니다!
아래에서 확인하기 어려우신 궁금증은 wiki에서 확인하실 수 있습니다!

### 메모리 max설정 기준
사용자 `4명 기준`으로 `1판` 진행 시 용량을 계산해 봤습니다. (변경 가능성 有)

아트워크 이미지(300KB)
- 내가 허밍 할 화면: 30KB (6개) → 180KB
- 정답 맞추기 화면: 30KB (4개) → 120KB

음성(허밍)파일 (120KB)
- 내가 허밍한 음악 파일: 30KB
- 내가 듣는 음성 파일: 30KB (3개) → 90KB

노래 파일 (10MB)
- 내가 허밍 할 화면:1MB (6개) → 6MB
- 정답 맞추기 화면 1MB (4개) → 4MB

아바타 이미지(650KB)
- total: 650KB

👉🏻 총 11.36MB가 나오고, 모드가 1개 추가될 예정이기에 그 부분까지 고려해서 350MB로 잡아줬습니다.
(게임 모드 1개당 15번 플레이)

### 메모리 max설정 기준
구조체로 스택에 계속 올라갔다 내려오는 것보다는 class로 힙에 올려두고 관리해 주는 것이 조금 더 효율적이라고 판단해서 class로 변경했습니다.