### PR TITLE
[Refactor] 로비 화면 캐러셀 사용성 개선

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/SnapperView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/SwiftUIComponents/SnapperView.swift
@@ -43,10 +43,10 @@ struct SnapperView: View {
                     isDragging = false
                     totalDrag = 0.0
                     
-                    if (value.translation.width < -(cardWidth / 2.0) && self.currentMode.Index < modeInfos.count) {
+                    if (value.translation.width < -(cardWidth / 5.0) && self.currentMode.Index < modeInfos.count) {
                         self.currentMode = Mode.fromIndex(self.currentMode.Index + 1) ?? .harmony
                     }
-                    if (value.translation.width > (cardWidth / 2.0) && self.currentMode.Index > 1) {
+                    if (value.translation.width > (cardWidth / 5.0) && self.currentMode.Index > 1) {
                         self.currentMode = Mode.fromIndex(self.currentMode.Index - 1) ?? .harmony
                     }
             }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -26,6 +26,11 @@ final class LobbyViewController: UIViewController {
         bindToComponents()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        lobbyView.view = nil
+    }
+
     private func bindToComponents() {
         viewmodel.$canBeginGame.combineLatest(viewmodel.$isHost)
             .receive(on: DispatchQueue.main)


### PR DESCRIPTION
## 관련 이슈

- #12 

## 완료 및 수정 내역

 - [x] 캐러셀 스와이프 민감도 개선
 - [x] 캐러셀 잔상이 onBoarding 화면에 남는 문제 해결

## 리뷰 노트
### 민감도 개선
기존에는 사용자가 스와이프를 1/2 이상 해야 스와이프가 작동했습니다.

```swift
if (value.translation.width < -(cardWidth / 2.0) && self.currentMode.Index < modeInfos.count) {
    self.currentMode = Mode.fromIndex(self.currentMode.Index + 1) ?? .harmony
}
if (value.translation.width > (cardWidth / 520) && self.currentMode.Index > 1) {
    self.currentMode = Mode.fromIndex(self.currentMode.Index - 1) ?? .harmony
}
```
하지만, 민감도가 너무 낮아 사용자 입장에서 생각보다 많이 스와이프를 해야만 캐러셀이 넘어간다 느껴질 수 있다는 문제가 제기됐습니다.
따라서 해당 값을 조정하기로 결정, 테스트를 병행하여 1/5의 값이 충분하다는 결론을 도출했습니다.

### 캐러셀 잔상이 로비에서 온보딩 화면으로 돌아왔을 때 남아있는 문제 해결
기존에는 로비에서 사용자가 캐러셀을 스와이프한 뒤, 다시 <뒤로가기> 버튼을 통해 온보딩 화면으로 돌아왔을 때 캐러셀의 잔상이 약 1초 가량 남아있는 문제가 있었습니다.

문제 원인으로는
1. SwiftUI와 UIKit의 상태 동기화 문제: 
    UIHostingController가 뷰를 완전히 제거하기 전에 SwiftUI의 상태가 업데이트되지 않아서 뷰의 일부가 남아있게 되고, 특히 애니메이션 기반 컴포넌트에서 SwiftUI가 GeometryReader를 사용하면서 레이아웃 상태를 제대로 업데이트 하지 못하는 경우 발생
2. 캐러셀 애니메이션 종료 후 상태 정리 문제:
    SnapperView 내부에서 스와이프 애니메이션이 완료되지 않은 상태에서의 화면 전환으로 발생하는 잔상
3. UIHostingController 메모리 해제 지연:
    UIHostingController가 제대로 메모리에서 해제되지 않아 온보딩 화면에 잔상이 남는 경우 발생

이 중 3번 즉, UIHostingController의 메모리를 viewWillDisappear에서 해제하게 한다면 1-3번의 문제가 모두 해결되지 않을까 생각했습니다.

따라서 LobbyViewController에 해당 코드를 추가한 뒤, 테스트로 확인하니 예상대로 정상적으로 작동함을 알 수 있었습니다.
```swift
override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)
    lobbyView.view = nil
}
```
## 스크린샷(선택)

https://github.com/user-attachments/assets/bab942c7-e3dd-458d-84b7-d5598f941a8a

