### PR TITLE
[Refactor] 캐시된 데이터의 메타데이터 접근 방식 변경

### DIFF
--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/CachedFile.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/CachedFile.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct CachedFile {
+    let url: URL
+    let size: Int
+    let lastModifiedDate: Date
+}
+

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/CachedFile.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/CachedFile.swift
@@ -3,6 +3,6 @@ import Foundation
 struct CachedFile {
     let url: URL
     let size: Int
-    let lastModifiedDate: Date
+    let modificationDate: Date
 }
 

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
@@ -40,7 +40,6 @@ final class DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
     }
     
     /// 캐시를 최적화하는 메서드
-    /// comment
     ///
     /// 설정해둔 max 용량보다 크면 가장 사용한지 오래된 캐시를 지웁니다.
     private func optimizeCache() {

--- a/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
+++ b/alsongDalsong/ASCacheKit/ASCacheKit/Core/Source/DiskCache.swift
@@ -46,7 +46,7 @@ final class DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
         let (totalSize, cachedFilesMetaData) = getCachedFileMetaData()
         guard totalSize > maxSize else { return }
         
-        let sortedFiles = cachedFilesMetaData.sorted { $0.lastModifiedDate < $1.lastModifiedDate }
+        let sortedFiles = cachedFilesMetaData.sorted { $0.modificationDate < $1.modificationDate }
         
         var remainingSize = totalSize
         for metaData in sortedFiles {
@@ -75,7 +75,7 @@ final class DiskCacheManager: @unchecked Sendable, DiskCacheManagerProtocol {
             let modificationDate = resourceValues?.contentModificationDate ?? Date.distantPast
             
             totalSize += fileSize
-            cachedFilesMetaData.append(CachedFile(url: fileURL, size: fileSize, lastModifiedDate: modificationDate))
+            cachedFilesMetaData.append(CachedFile(url: fileURL, size: fileSize, modificationDate: modificationDate))
         }
         
         return (totalSize, cachedFilesMetaData)


### PR DESCRIPTION
## 관련 이슈
- #20 
- #2

## 완료 및 수정 내역
 - [ ] 메타데이터 접근 방식 변경

## 리뷰 노트

기존에는 캐싱된 데이터 크기를 먼저 구하고, 크면 다시 수정날짜를 가져와서 정렬해주는 방식이었습니다.
이렇게 구현했더던 이유는 resourceValues가 결국 캐싱된 URL의 메타데이터를 가져오기 때문에 백킹 스토어에 다시 접근하지 않기 때문이었습니다.

![resourceValues](https://github.com/user-attachments/assets/05cd3883-c27b-4d94-87bf-2260f2ef6fea)

```Swift
let totalSize = totalFiles.reduce(0) { sum, fileURL in
            let fileSize = try? fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize
            return sum + (fileSize ?? 0)

 let sortedFiles = totalFiles.sorted {
            let date1 = (try? $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date.distantPast
            let date2 = (try? $1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? Date.distantPast
            return date1 < date2
        }
```

그러나 코드의 흐름이 잘 읽히지 않고, 뒷문장을 확인해보면 캐싱된 값이 없다면 결국 백킹 스토어에 가서 메타데이터를 가져오기 때문에 만약의 상황을 대비해서 한번만 resourceValues를 사용하는게 맞다고 생각했습니다.

따라서 다음과 같이 사이즈를 가져올 때 한번에 최종 수정된 날짜도 가져와주는 방식으로 변경했습니다.

```Swift
for fileURL in totalFiles {
        let resourceValues = try? fileURL.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
        let fileSize = resourceValues?.fileSize ?? 0
        let modificationDate = resourceValues?.contentModificationDate ?? Date.distantPast
        
        totalSize += fileSize
        cachedFilesMetaData.append(CachedFile(url: fileURL, size: fileSize, lastModifiedDate: modificationDate))
    }
```

개인적으로 생각했을 때 가독성은 훨씬 좋아진 것 같지만 결국 캐싱된 메타데이터를 가져오는 것이기에 성능면에서는 큰 차이가 없다고 판단이 되는데 여러분의 의견이 궁금합니다..! 

## 스크린샷(선택)
