### PR TITLE
[Refactor] ASLogKit 방식, 타입이름 변경

### DIFF
--- a/alsongDalsong/ASLogKit/ASLogKit/Logger.swift
+++ b/alsongDalsong/ASLogKit/ASLogKit/Logger.swift
@@ -1,9 +1,10 @@
 import Foundation
-import os.log
+import os
+import OSLog
 
 public enum Logger {
-    private static var logger: os.Logger {
-        return os.Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.unknown.app", category: "Logger")
+    private static var logger: OSLog {
+        return OSLog(subsystem: Bundle.main.bundleIdentifier ?? "com.unknown.app", category: "Logger")
     }
 
     public static func debug(_ items: Any..., separator: String = " ", terminator: String = "\n") {
@@ -14,33 +15,35 @@ public enum Logger {
         log(.info, items, separator: separator, terminator: terminator)
     }
 
-    public static func warning(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-        log(.warning, items, separator: separator, terminator: terminator)
+    public static func fault(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+        log(.fault, items, separator: separator, terminator: terminator)
     }
 
     public static func error(_ items: Any..., separator: String = " ", terminator: String = "\n") {
         log(.error, items, separator: separator, terminator: terminator)
     }
 
-    public static func critical(_ items: Any..., separator: String = " ", terminator: String = "\n") {
-        log(.critical, items, separator: separator, terminator: terminator)
+    public static func notice(_ items: Any..., separator: String = " ", terminator: String = "\n") {
+        log(.default, items, separator: separator, terminator: terminator)
     }
 
     private static func log(_ level: LogLevel, _ items: [Any], separator: String, terminator _: String) {
         #if DEBUG
             let message = items.map { stringify($0) }.joined(separator: separator)
+            let osLogType: OSLogType
             switch level {
-                case .debug:
-                logger.debug("[\(level.rawValue)] \(message, privacy: .private)")
-                case .info:
-                logger.info("[\(level.rawValue)] \(message, privacy: .private)")
-                case .warning:
-                logger.warning("[\(level.rawValue)] \(message, privacy: .private)")
-                case .error:
-                logger.error("[\(level.rawValue)] \(message, privacy: .private)")
-                case .critical:
-                logger.fault("[\(level.rawValue)] \(message, privacy: .private)")
+            case .debug:
+                osLogType = .debug
+            case .info:
+                osLogType = .info
+            case .fault:
+                osLogType = .fault
+            case .error:
+                osLogType = .error
+            case .default:
+                osLogType = .default
             }
+            os_log("[%@] %{public}@", log: logger, type: osLogType, level.rawValue, message)
         #endif
     }
 
@@ -58,7 +61,7 @@ public enum Logger {
 enum LogLevel: String {
     case debug = "DEBUG"
     case info = "INFO"
-    case warning = "WARNING"
+    case fault = "FAULT"
     case error = "ERROR"
-    case critical = "CRITICAL"
+    case `default` = "NOTICE"
 }


### PR DESCRIPTION
## 관련 이슈

- #10 

## 완료 및 수정 내역

 - [x] 로그 방식을 os.log -> OSLog로 변경
 - [x] 타입, level 이름 변경

## 테스트 방법 (선택)

## 리뷰 노트

14 이후의 Swift에서는 os.log의 Log 방식보다 OSLog의 통합 로그 방식이 필터링에서 더 유의미 했고 os.log가 예전 방식의 로그여서 지원이 안되는 필터가 있었고, Console에서 캡쳐를 못하는 경우가 있어서 수정하게 되었습니다. 

## 스크린샷

### 전체 로그(Xcode 콘솔)
<img width="719" alt="image" src="https://github.com/user-attachments/assets/ebed1132-a1bf-4012-bc2e-de05895fcbfd" />

### Debug 필터
<img width="713" alt="image" src="https://github.com/user-attachments/assets/102ce8c2-6d17-4de3-84f9-4fa4f08f1171" />

### Info 필터
<img width="712" alt="image" src="https://github.com/user-attachments/assets/d4af8819-0e6f-4b6a-a609-55146ff32757" />

### Notice 필터
<img width="715" alt="image" src="https://github.com/user-attachments/assets/842c8b3a-f443-4309-86e3-caf30f4fb280" />

### Error 필터
<img width="712" alt="image" src="https://github.com/user-attachments/assets/7f15445a-3137-4f2e-8edc-b54c9e6924d0" />

### Fault 필터
<img width="716" alt="image" src="https://github.com/user-attachments/assets/2c2cc1b9-74cb-4543-904a-fd996c60a9fc" />

### Console 앱에서 (Debug, Info는 원래 캡처 안됨)
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/2a929ecd-1e1f-4834-98c9-81c7a2df2022" />
