### PR TITLE
[Refactor] 화면 전환 될 때 노래 중지

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/MusicPanel/MusicPanelViewModel.swift
@@ -25,6 +25,12 @@ final class MusicPanelViewModel: @unchecked Sendable {
         bindAudioHelper()
     }
 
+    deinit {
+        Task {
+            await AudioHelper.shared.stopPlaying()
+        }
+    }
+
     private func bindAudioHelper() {
         Task {
             await AudioHelper.shared.playerStatePublisher
@@ -82,7 +88,6 @@ final class MusicPanelViewModel: @unchecked Sendable {
         if self.type == type {
             buttonState = state
         }
-
     }
 
     private func getPreviewData() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -44,6 +44,10 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         bindSearchTerm()
     }
     
+    deinit {
+        stopMusic()
+    }
+    
     private func bindGameStatus() {
         gameStatusRepository.getDueTime()
             .receive(on: DispatchQueue.main)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -46,6 +46,10 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         bindSearchTerm()
     }
 
+    deinit {
+        stopMusic()
+    }
+
     private func bindSearchTerm() {
         $searchTerm
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)


### PR DESCRIPTION
## 관련 이슈

- #24 

## 완료 및 수정 내역

### 노래 혹은 음성을 재생할 수 있는 부분에서 화면전환시 중지 적용
 - [x] 노래선택화면
 - [x] 허밍 화면의 노래 플레이어
 - [x] 리허밍의 녹음파일 플레이어
 - [x] 정답 제출화면 

## 테스트 방법 (선택)

## 리뷰 노트

기존의 프로젝트에서 노래 혹은 음성파일을 재생하는 와중에 좌측상단의 홈으로 가기, 로비로 돌아가기 버튼을 누를 시에 노래가 멈추지않는 문제가 있었음. 이 부분을 해결하고자 하였음. musicPlayer를 관리하는 VM이 deinit 되는 시점에 중지하도록 변경하였음
## 스크린샷(선택)
