### PR TITLE
[Hotfix] 캐러셀이 다시 보이지 않는 문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -18,6 +18,11 @@ final class LobbyViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        lobbyView = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()


### PR DESCRIPTION
## 관련 이슈

- #28 

## 완료 및 수정 내역

 - [x] 2회차 이상의 게임에서 LobbyView의 캐러셀이 다시 나오지 않는 문제 해결

## 리뷰 노트

viewWillAppear에 다시 캐러셀을 넣어주도록 수정했습니다.

```swift
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        lobbyView = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
    }
```