### PR TITLE
[Feat] Mock Data를 이용한 View 별 Preview 구현

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/GameState.swift
+++ b/alsongDalsong/ASEntity/ASEntity/GameState.swift
@@ -130,3 +130,48 @@ public enum GameViewType {
         }
     }
 }
+
+extension GameState {
+    static let submitMusicStub: GameState = GameState(
+        mode: .humming,
+        recordOrder: 0,
+        status: .humming,
+        round: 0,
+        players: [Player.playerStub1, Player.playerStub2, Player.playerStub3, Player.playerStub4]
+    )
+    static let hummingStub: GameState = GameState(
+        mode: .humming,
+        recordOrder: 0,
+        status: .humming,
+        round: 1,
+        players: [Player.playerStub1, Player.playerStub2, Player.playerStub3, Player.playerStub4]
+    )
+    static let rehummingStub: GameState = GameState(
+        mode: .humming,
+        recordOrder: 1,
+        status: .rehumming,
+        round: 1,
+        players: [Player.playerStub1, Player.playerStub2, Player.playerStub3, Player.playerStub4]
+    )
+    static let submitAnswerStub: GameState = GameState(
+        mode: .humming,
+        recordOrder: 3,
+        status: .rehumming,
+        round: 1,
+        players: [Player.playerStub1, Player.playerStub2, Player.playerStub3, Player.playerStub4]
+    )
+    static let resultStub: GameState = GameState(
+        mode: .humming,
+        recordOrder: 3,
+        status: .result,
+        round: 1,
+        players: [Player.playerStub1, Player.playerStub2, Player.playerStub3, Player.playerStub4]
+    )
+    static let lobbyStub: GameState = GameState(
+        mode: .humming,
+        recordOrder: nil,
+        status: nil,
+        round: nil,
+        players: [Player.playerStub1, Player.playerStub2, Player.playerStub3, Player.playerStub4]
+    )
+}

--- a/alsongDalsong/ASEntity/ASEntity/Music.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Music.swift
@@ -32,7 +32,14 @@ extension Music {
 }
 
 extension Music {
-    public static let musicStub1 = Music(title: "네 번호가 뜨는 일", artist: "이예준")
+    public static let musicStub1 = Music(
+        id: "1",
+        title: "네 번호가 뜨는 일",
+        artist: "이예준",
+        artworkUrl: URL(string:"https://is1-ssl.mzstatic.com/image/thumb/Music123/v4/94/d1/27/94d12730-39c3-53a9-fdc3-52ca01e33d79/cover_KM0016750_1.jpg/300x300bb.jpg"),
+        previewUrl: URL(string: "https://audio-ssl.itunes.apple.com/itunes-assets/AudioPreview113/v4/05/c7/fe/05c7fe7b-4871-5dde-9f13-46bada057623/mzaf_8929995540220645309.plus.aac.p.m4a"),
+        artworkBackgroundColor: "92897a"
+    )
     public static let musicStub2 = Music(title: "그거 아세요?", artist: "이혁")
     public static let musicStub3 = Music(title: "으아~", artist: "김흥국")
     public static let musicStub4 = Music(title: "이브, 프시케 그리고 푸른 수염의 아내", artist: "르세라핌")

--- a/alsongDalsong/ASEntity/ASEntity/Player.swift
+++ b/alsongDalsong/ASEntity/ASEntity/Player.swift
@@ -20,8 +20,28 @@ public struct Player: Codable, Equatable, Identifiable, Sendable, Hashable {
 }
 
 extension Player {
-    public static let playerStub1: Player = Player(id: "0", avatarUrl: nil, nickname: "Tltlbo", order: 0)
-    public static let playerStub2: Player = Player(id: "1", avatarUrl: nil, nickname: "Sonny", order: 1)
-    public static let playerStub3: Player = Player(id: "2", avatarUrl: nil, nickname: "Moral-life", order: 2)
-    public static let playerStub4: Player = Player(id: "3", avatarUrl: nil, nickname: "Sang₩", order: 3)
+    public static let playerStub1: Player = Player(
+        id: "0",
+        avatarUrl: URL(string: "https://avatars.githubusercontent.com/u/86788943?v=4"),
+        nickname: "around-forest",
+        order: 0
+    )
+    public static let playerStub2: Player = Player(
+        id: "1",
+        avatarUrl: URL(string: "https://avatars.githubusercontent.com/u/131857557?v=4"),
+        nickname: "INYEKIM",
+        order: 1
+    )
+    public static let playerStub3: Player = Player(
+        id: "2",
+        avatarUrl: URL(string: "https://avatars.githubusercontent.com/u/120548537?v=4"),
+        nickname: "hyunjuntyler",
+        order: 2
+    )
+    public static let playerStub4: Player = Player(
+        id: "3",
+        avatarUrl: URL(string: "https://avatars.githubusercontent.com/u/28076019?v=4"),
+        nickname: "moral-life",
+        order: 3
+    )
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/AnswersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/AnswersMockRepository.swift
@@ -20,15 +20,11 @@ public final class AnswersMockRepository: AnswersRepositoryProtocol {
     }
 
     public func getMyAnswer() -> AnyPublisher<Answer?, Never> {
-        answersPublisher
-            .map { answers in
-                answers.first { $0.player?.id == Player.playerStub1.id }
-            }
+        Just(Answer.answerStub1)
             .eraseToAnyPublisher()
     }
 
     public func submitMusic(answer: ASEntity.Music) async throws -> Bool {
-        answersPublisher.send(answersStub + [Answer.answerStub4])
         return true
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/AnswersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/AnswersMockRepository.swift
@@ -1,0 +1,36 @@
+import ASEntity
+import ASNetworkKit
+import ASRepositoryProtocol
+import Combine
+
+public final class AnswersMockRepository: AnswersRepositoryProtocol {
+    // MARK: 3개의 더미 데이터로 대체
+
+    private let answersStub = [Answer.answerStub2, Answer.answerStub3, Answer.answerStub4]
+    private let answersPublisher: CurrentValueSubject<[Answer], Never> = .init([])
+
+    public init() {
+        answersPublisher.send(answersStub)
+    }
+
+    public func getAnswersCount() -> AnyPublisher<Int, Never> {
+        answersPublisher
+            .receive(on: DispatchQueue.main)
+            .map(\.count)
+            .eraseToAnyPublisher()
+    }
+
+    public func getMyAnswer() -> AnyPublisher<Answer?, Never> {
+        answersPublisher
+            .receive(on: DispatchQueue.main)
+            .map { answers in
+                answers.first { $0.player?.id == Player.playerStub1.id }
+            }
+            .eraseToAnyPublisher()
+    }
+
+    public func submitMusic(answer: ASEntity.Music) async throws -> Bool {
+        answersPublisher.send(answersStub + [Answer.answerStub4])
+        return true
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/AnswersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/AnswersMockRepository.swift
@@ -15,14 +15,12 @@ public final class AnswersMockRepository: AnswersRepositoryProtocol {
 
     public func getAnswersCount() -> AnyPublisher<Int, Never> {
         answersPublisher
-            .receive(on: DispatchQueue.main)
             .map(\.count)
             .eraseToAnyPublisher()
     }
 
     public func getMyAnswer() -> AnyPublisher<Answer?, Never> {
         answersPublisher
-            .receive(on: DispatchQueue.main)
             .map { answers in
                 answers.first { $0.player?.id == Player.playerStub1.id }
             }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/AvatarMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/AvatarMockRepository.swift
@@ -1,0 +1,14 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class AvatarMockRepository: AvatarRepositoryProtocol {
+    public func getAvatarUrls() async throws -> [URL] {
+        [
+            Player.playerStub1,
+            Player.playerStub2,
+            Player.playerStub3,
+            Player.playerStub4
+        ].compactMap(\.avatarUrl)
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/AvatarMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/AvatarMockRepository.swift
@@ -3,6 +3,8 @@ import ASRepositoryProtocol
 import Combine
 
 public final class AvatarMockRepository: AvatarRepositoryProtocol {
+    public init() {}
+
     public func getAvatarUrls() async throws -> [URL] {
         [
             Player.playerStub1,

--- a/alsongDalsong/ASRepository/ASRepository/Mock/DataDownloadMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/DataDownloadMockRepository.swift
@@ -1,0 +1,20 @@
+import ASNetworkKit
+import ASRepositoryProtocol
+
+public final class DataDownloadMockRepository: DataDownloadRepositoryProtocol {
+    private var networkManager: ASNetworkManagerProtocol
+
+    public init(networkManager: ASNetworkManagerProtocol) {
+        self.networkManager = networkManager
+    }
+
+    public func downloadData(url: URL) async -> Data? {
+        guard let endpoint = ResourceEndpoint(url: url) else { return nil }
+        do {
+            let data = try await networkManager.sendRequest(to: endpoint, type: .none, body: nil, option: .none)
+            return data
+        } catch {
+            return nil
+        }
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/GameStateMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/GameStateMockRepository.swift
@@ -16,7 +16,6 @@ public final class GameStateMockRepository: GameStateRepositoryProtocol {
 
     public func getGameState() -> AnyPublisher<ASEntity.GameState?, Never> {
         gameStatePublisher
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/GameStateMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/GameStateMockRepository.swift
@@ -1,0 +1,22 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class GameStateMockRepository: GameStateRepositoryProtocol {
+    private let gameStatePublisher = CurrentValueSubject<ASEntity.GameState?, Never>(nil)
+
+    public init(state: GameState) {
+        switch state.mode {
+        case .humming:
+            gameStatePublisher.send(state)
+        default:
+            break
+        }
+    }
+
+    public func getGameState() -> AnyPublisher<ASEntity.GameState?, Never> {
+        gameStatePublisher
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/GameStatusMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/GameStatusMockRepository.swift
@@ -24,20 +24,17 @@ public final class GameStatusMockRepository: GameStatusRepositoryProtocol {
     
     public func getStatus() -> AnyPublisher<Status?, Never> {
         statusPublisher
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
     
     public func getRecordOrder() -> AnyPublisher<UInt8, Never> {
         recordOrderPublisher
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
     
     public func getDueTime() -> AnyPublisher<Date, Never> {
         dueTimePublisher
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/GameStatusMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/GameStatusMockRepository.swift
@@ -1,0 +1,44 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class GameStatusMockRepository: GameStatusRepositoryProtocol {
+    private let statusPublisher = CurrentValueSubject<Status?, Never>(nil)
+    private let recordOrderPublisher = CurrentValueSubject<UInt8?, Never>(nil)
+    private let dueTimePublisher = CurrentValueSubject<Date?, Never>(nil)
+    
+    public init(status: Status) {
+        statusPublisher.send(status)
+        dueTimePublisher.send(Date().addingTimeInterval(60))
+        switch status {
+        case .humming:
+            recordOrderPublisher.send(0)
+        case .rehumming:
+            recordOrderPublisher.send(1)
+        case .result:
+            recordOrderPublisher.send(2)
+        default:
+            break
+        }
+    }
+    
+    public func getStatus() -> AnyPublisher<Status?, Never> {
+        statusPublisher
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+    
+    public func getRecordOrder() -> AnyPublisher<UInt8, Never> {
+        recordOrderPublisher
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+    }
+    
+    public func getDueTime() -> AnyPublisher<Date, Never> {
+        dueTimePublisher
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/HummingResultMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/HummingResultMockRepository.swift
@@ -1,0 +1,49 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class HummingResultMockRepository: HummingResultRepositoryProtocol {
+    private let answers = [
+        Answer.answerStub1,
+        Answer.answerStub2,
+        Answer.answerStub3,
+        Answer.answerStub4
+    ]
+    private let records = [
+        [Record.recordStub1_1, Record.recordStub1_2, Record.recordStub1_3],
+        [Record.recordStub2_1, Record.recordStub2_2, Record.recordStub2_3],
+        [Record.recordStub3_1, Record.recordStub3_2, Record.recordStub3_3],
+        [Record.recordStub4_1, Record.recordStub4_2, Record.recordStub4_3]
+    ]
+    private let submits = [
+        Answer.answerStub1,
+        Answer.answerStub2,
+        Answer.answerStub3,
+        Answer.answerStub4
+    ]
+    private var recordOrders: UInt8 = 3
+    private var index = 0
+
+    public init() {}
+
+    public func getResult() ->
+        AnyPublisher<[(
+            answer: Answer,
+            records: [ASEntity.Record],
+            submit: Answer,
+            recordOrder: UInt8
+        )], Never>
+    {
+        let result = answers.map { answer in
+            let records = self.records[index]
+            let submit = submits[index]
+            let recordOrder = recordOrders
+            recordOrders += 1
+            index += 1
+            return (answer, records, submit, recordOrder)
+        }
+        return Just(result)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/HummingResultMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/HummingResultMockRepository.swift
@@ -10,16 +10,16 @@ public final class HummingResultMockRepository: HummingResultRepositoryProtocol 
         Answer.answerStub4
     ]
     private let records = [
-        [Record.recordStub1_1, Record.recordStub1_2, Record.recordStub1_3],
-        [Record.recordStub2_1, Record.recordStub2_2, Record.recordStub2_3],
-        [Record.recordStub3_1, Record.recordStub3_2, Record.recordStub3_3],
-        [Record.recordStub4_1, Record.recordStub4_2, Record.recordStub4_3]
+        [Record.recordStub1_1, Record.recordStub2_2, Record.recordStub3_3],
+        [Record.recordStub2_1, Record.recordStub3_2, Record.recordStub4_3],
+        [Record.recordStub3_1, Record.recordStub4_2, Record.recordStub1_3],
+        [Record.recordStub4_1, Record.recordStub1_2, Record.recordStub2_3],
     ]
     private let submits = [
-        Answer.answerStub1,
-        Answer.answerStub2,
+        Answer.answerStub4,
         Answer.answerStub3,
-        Answer.answerStub4
+        Answer.answerStub2,
+        Answer.answerStub1
     ]
     private var recordOrders: UInt8 = 3
     private var index = 0
@@ -43,7 +43,6 @@ public final class HummingResultMockRepository: HummingResultRepositoryProtocol 
             return (answer, records, submit, recordOrder)
         }
         return Just(result)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
@@ -1,0 +1,44 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class PlayersMockRepository: PlayersRepositoryProtocol {
+    private let playersStub = [
+        Player.playerStub1,
+        Player.playerStub2,
+        Player.playerStub3,
+        Player.playerStub4
+    ]
+    private let playersPublisher = CurrentValueSubject<[Player], Never>([])
+    
+    public init() {
+        playersPublisher.send(playersStub)
+    }
+    
+    public func getPlayers() -> AnyPublisher<[Player], Never> {
+        playersPublisher
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+    }
+    
+    public func getPlayersCount() -> AnyPublisher<Int, Never> {
+        playersPublisher
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .map(\.count)
+            .eraseToAnyPublisher()
+    }
+    
+    public func getHost() -> AnyPublisher<Player, Never> {
+        Just(Player.playerStub1)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+    
+    public func isHost() -> AnyPublisher<Bool, Never> {
+        Just(true)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
@@ -17,14 +17,12 @@ public final class PlayersMockRepository: PlayersRepositoryProtocol {
     
     public func getPlayers() -> AnyPublisher<[Player], Never> {
         playersPublisher
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
     
     public func getPlayersCount() -> AnyPublisher<Int, Never> {
         playersPublisher
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .map(\.count)
             .eraseToAnyPublisher()
@@ -32,13 +30,11 @@ public final class PlayersMockRepository: PlayersRepositoryProtocol {
     
     public func getHost() -> AnyPublisher<Player, Never> {
         Just(Player.playerStub1)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
     
     public func isHost() -> AnyPublisher<Bool, Never> {
         Just(true)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/RecordsMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/RecordsMockRepository.swift
@@ -12,14 +12,12 @@ public final class RecordsMockRepository: RecordsRepositoryProtocol {
 
     public func getRecordsCount(on recordOrder: UInt8) -> AnyPublisher<Int, Never> {
         recordsPublisher
-            .receive(on: DispatchQueue.main)
             .map(\.count)
             .eraseToAnyPublisher()
     }
 
     public func getHumming(on recordOrder: UInt8) -> AnyPublisher<ASEntity.Record?, Never> {
         Just(recordsStub.first)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 

--- a/alsongDalsong/ASRepository/ASRepository/Mock/RecordsMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/RecordsMockRepository.swift
@@ -1,0 +1,29 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class RecordsMockRepository: RecordsRepositoryProtocol {
+    private let recordsStub = [Record.recordStub1_1, Record.recordStub1_2, Record.recordStub1_3]
+    private let recordsPublisher: CurrentValueSubject<[ASEntity.Record], Never> = .init([])
+
+    public init() {
+        recordsPublisher.send(recordsStub)
+    }
+
+    public func getRecordsCount(on recordOrder: UInt8) -> AnyPublisher<Int, Never> {
+        recordsPublisher
+            .receive(on: DispatchQueue.main)
+            .map(\.count)
+            .eraseToAnyPublisher()
+    }
+
+    public func getHumming(on recordOrder: UInt8) -> AnyPublisher<ASEntity.Record?, Never> {
+        Just(recordsStub.first)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    public func uploadRecording(_ record: Data) async throws -> Bool {
+        true
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/RoomActionMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/RoomActionMockRepository.swift
@@ -1,0 +1,35 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class RoomActionMockRepository: RoomActionRepositoryProtocol {
+    public init() {}
+    
+    public func createRoom(nickname: String, avatar: URL) async throws -> String {
+        "000000"
+    }
+    
+    public func joinRoom(nickname: String, avatar: URL, roomNumber: String) async throws -> Bool {
+        true
+    }
+    
+    public func leaveRoom() async throws -> Bool {
+        true
+    }
+    
+    public func startGame(roomNumber: String) async throws -> Bool {
+        true
+    }
+    
+    public func changeMode(roomNumber: String, mode: ASEntity.Mode) async throws -> Bool {
+        true
+    }
+    
+    public func changeRecordOrder(roomNumber: String) async throws -> Bool {
+        true
+    }
+    
+    public func resetGame() async throws -> Bool {
+        true
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/RoomInfoMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/RoomInfoMockRepository.swift
@@ -1,0 +1,20 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class RoomInfoMockRepository: RoomInfoRepositoryProtocol {
+    public init() {}
+
+    public func getRoomNumber() -> AnyPublisher<String, Never> {
+        Just("000000")
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+    }
+
+    public func getMode() -> AnyPublisher<Mode, Never> {
+        Just(.humming)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/RoomInfoMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/RoomInfoMockRepository.swift
@@ -7,14 +7,12 @@ public final class RoomInfoMockRepository: RoomInfoRepositoryProtocol {
 
     public func getRoomNumber() -> AnyPublisher<String, Never> {
         Just("000000")
-            .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
     }
 
     public func getMode() -> AnyPublisher<Mode, Never> {
         Just(.humming)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Mock/SubmitsMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/SubmitsMockRepository.swift
@@ -1,0 +1,17 @@
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+
+public final class SubmitsMockRepository: SubmitsRepositoryProtocol {
+    public init() {}
+
+    public func getSubmitsCount() -> AnyPublisher<Int, Never> {
+        Just(3)
+            .receive(on: DispatchQueue.main)
+            .eraseToAnyPublisher()
+    }
+
+    public func submitAnswer(answer: Music) async throws -> Bool {
+        true
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/SubmitsMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/SubmitsMockRepository.swift
@@ -7,7 +7,6 @@ public final class SubmitsMockRepository: SubmitsRepositoryProtocol {
 
     public func getSubmitsCount() -> AnyPublisher<Int, Never> {
         Just(3)
-            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/AppDelegate.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/AppDelegate.swift
@@ -1,12 +1,23 @@
 import UIKit
+import FirebaseCore
+import ASContainer
+import ASRepository
+import ASNetworkKit
+import ASCacheKit
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        FirebaseApp.configure()
+        assembleDependencies()
         return true
     }
 
     func application(_: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options _: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+    
+    private func assembleDependencies() {
+        DIContainer.shared.addAssemblies([CacheAssembly(), NetworkAssembly(), RepsotioryAssembly()])
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/UIViewController+Preview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Extensions/UIViewController+Preview.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+#if DEBUG
+extension UIViewController {
+    private struct Preview: UIViewControllerRepresentable {
+        let viewController: UIViewController
+        
+        func makeUIViewController(context: Context) -> UIViewController {
+            return viewController
+        }
+        
+        func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        }
+    }
+    
+    func toPreview() -> some View {
+        Preview(viewController: self)
+    }
+}
+#endif

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/SceneDelegate.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/SceneDelegate.swift
@@ -1,10 +1,7 @@
-import ASCacheKit
 import ASContainer
 import ASLogKit
 import ASNetworkKit
-import ASRepository
 import ASRepositoryProtocol
-import Firebase
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
@@ -15,9 +12,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                options connectionOptions: UIScene.ConnectionOptions)
     {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        FirebaseApp.configure()
         ASFirebaseAuth.configure()
-        assembleDependencies()
         var inviteCode = ""
         
         if let url = connectionOptions.urlContexts.first?.url {
@@ -51,9 +46,5 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 Logger.error(error.localizedDescription)
             }
         }
-    }
-    
-    private func assembleDependencies() {
-        DIContainer.shared.addAssemblies([CacheAssembly(), NetworkAssembly(), RepsotioryAssembly()])
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingPreview.swift
@@ -5,7 +5,6 @@ import SwiftUI
 import UIKit
 
 struct HummingPreview: PreviewProvider {
-    @UIApplicationDelegateAdaptor(AppDelegate.self) static var appDelegate
     static var previews: some View {
         let gameStatusRepository = GameStatusMockRepository(status: .humming)
         let playerRepository = PlayersMockRepository()

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingPreview.swift
@@ -1,0 +1,22 @@
+import ASContainer
+import ASRepository
+import ASRepositoryProtocol
+import SwiftUI
+import UIKit
+
+struct HummingPreview: PreviewProvider {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) static var appDelegate
+    static var previews: some View {
+        let gameStatusRepository = GameStatusMockRepository(status: .humming)
+        let playerRepository = PlayersMockRepository()
+        let answersRepository = AnswersMockRepository()
+        let recordsRepository = RecordsMockRepository()
+        let hummingViewModel = HummingViewModel(
+            gameStatusRepository: gameStatusRepository,
+            playersRepository: playerRepository,
+            answersRepository: answersRepository,
+            recordsRepository: recordsRepository
+        )
+        return HummingViewController(viewModel: hummingViewModel).toPreview()
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyPreview.swift
@@ -1,0 +1,22 @@
+import ASContainer
+import ASRepository
+import ASRepositoryProtocol
+import SwiftUI
+import UIKit
+
+struct LobbyPreview: PreviewProvider {
+    static var previews: some View {
+        let playerRepository = PlayersMockRepository()
+        let roomInfoRepository = RoomInfoMockRepository()
+        let roomActionRepository = RoomActionMockRepository()
+        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+
+        let lobbyViewModel = LobbyViewModel(
+            playersRepository: playerRepository,
+            roomInfoRepository: roomInfoRepository,
+            roomActionRepository: roomActionRepository,
+            dataDownloadRepository: dataDownloadRepository
+        )
+        return LobbyViewController(lobbyViewModel: lobbyViewModel).toPreview()
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingPreview.swift
@@ -1,0 +1,24 @@
+import ASContainer
+import ASRepository
+import ASRepositoryProtocol
+import SwiftUI
+import UIKit
+
+struct OnboardingPreview: PreviewProvider {
+    static var previews: some View {
+        let roomActionRepository = RoomActionMockRepository()
+        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+
+        let onboardingViewModel = OnboardingViewModel(
+            roomActionRepository: roomActionRepository,
+            dataDownloadRepository: dataDownloadRepository,
+            avatars: [],
+            selectedAvatar: nil,
+            avatarData: nil
+        )
+        return OnboardingViewController(
+            viewModel: onboardingViewModel,
+            inviteCode: ""
+        ).toPreview()
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/ReHummingPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/ReHummingPreview.swift
@@ -1,0 +1,19 @@
+import ASContainer
+import ASRepository
+import ASRepositoryProtocol
+import SwiftUI
+import UIKit
+
+struct ReHummingPreview: PreviewProvider {
+    static var previews: some View {
+        let gameStatusRepository = GameStatusMockRepository(status: .humming)
+        let playerRepository = PlayersMockRepository()
+        let recordsRepository = RecordsMockRepository()
+        let rehummingViewModel = RehummingViewModel(
+            gameStatusRepository: gameStatusRepository,
+            playersRepository: playerRepository,
+            recordsRepository: recordsRepository
+        )
+        return RehummingViewController(viewModel: rehummingViewModel).toPreview()
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultPreview.swift
@@ -1,0 +1,25 @@
+import ASContainer
+import ASRepository
+import ASRepositoryProtocol
+import SwiftUI
+import UIKit
+
+struct HummingResultPreview: PreviewProvider {
+    static var previews: some View {
+        let hummingResultRepository = HummingResultMockRepository()
+        let gameStatusRepository = GameStatusMockRepository(status: .result)
+        let playerRepository = PlayersMockRepository()
+        let roomActionRepository = RoomActionMockRepository()
+        let roomInfoRepository = RoomInfoMockRepository()
+        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+        let hummingResultViewModel = HummingResultViewModel(
+            hummingResultRepository: hummingResultRepository,
+            gameStatusRepository: gameStatusRepository,
+            playerRepository: playerRepository,
+            roomActionRepository: roomActionRepository,
+            roomInfoRepository: roomInfoRepository,
+            dataDownloadRepository: dataDownloadRepository
+        )
+        return HummingResultViewController(viewModel: hummingResultViewModel).toPreview()
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #25

## 완료 및 수정 내역
- [x] Repository 내에서 필요한 Mock Data 생성
- [x] Humming Mode에서 사용하는 뷰의 SwiftUI Preview 활용

## 리뷰 노트
- 실제 앱과 유사한 환경을 위해 Demo App용 Target을 분리하는 방안을 고려했으나, 서버에서 받아오는 데이터를 어떻게 보여줄지에 더욱 집중하기 위해 Xcode Live Preview 기능을 우선적으로 적용하였습니다.
- 아쉬운 점은  첫번 째로 실제 앱 배포시에도 Repository에 있는 Mock 데이터가 같이 빌드될 수 있을 것 같습니다. 그리고 DataRepository 의 Mock을 만들기가 어렵다는 점,, (음성 Data와 Artwork 이미지를 혼합해서 사용하고있어서 Mock을 만들지 못해서 실제 Repository로 운용되고있습니다.)


## 스크린샷 (선택)
| Onboarding | Lobby | Humming |
| - | - | - |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/3b8b08f3-248c-4f9d-b568-adf6dbb903f9" /> |  <img width="300" alt="image" src="https://github.com/user-attachments/assets/be46e552-b011-4eb8-ab9b-5cd17ba6cee0" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/ea946ea5-b02b-4a99-913f-dcb32f76bdf9" /> |

| ReHumming | HummingResult | - |
| - | - | - |
| <img width="300" alt="image" src="https://github.com/user-attachments/assets/d894e0d5-a4e9-4a39-ace6-0e3ddd3dde37" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/04abc2aa-747b-4c08-b8fd-3fac8b82edb1" /> | - |
