### PR TITLE
[Refactor] 에러 핸들링 개선

### DIFF
--- a/alsongDalsong/ASAudioKit/ASAudioAnalyzer.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioAnalyzer.swift
@@ -44,7 +44,7 @@ public enum ASAudioAnalyzer {
 
             return result
         } catch {
-            throw ASAudioErrors.analyzeError(reason: error.localizedDescription)
+            throw ASAudioErrors(type: .analyze, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASAudioKit/ASAudioAnalyzer.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioAnalyzer.swift
@@ -3,45 +3,49 @@ import Foundation
 
 public enum ASAudioAnalyzer {
     public static func analyze(data: Data, samplesCount: Int) async throws -> [CGFloat] {
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".m4a")
-        try data.write(to: tempURL)
-        let file = try AVAudioFile(forReading: tempURL)
-        
-        guard
-            let format = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: file.fileFormat.sampleRate,
-                channels: file.fileFormat.channelCount,
-                interleaved: false
-            ),
-            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
-        else {
-            return []
+        do {
+            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString + ".m4a")
+            try data.write(to: tempURL)
+            let file = try AVAudioFile(forReading: tempURL)
+
+            guard
+                let format = AVAudioFormat(
+                    commonFormat: .pcmFormatFloat32,
+                    sampleRate: file.fileFormat.sampleRate,
+                    channels: file.fileFormat.channelCount,
+                    interleaved: false
+                ),
+                let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
+            else {
+                return []
+            }
+
+            try file.read(into: buffer)
+            guard let floatChannelData = buffer.floatChannelData else {
+                return []
+            }
+
+            let frameLength = Int(buffer.frameLength)
+            let samples = Array(UnsafeBufferPointer(start: floatChannelData[0], count: frameLength))
+            var result = [CGFloat]()
+            let chunkedSamples = samples.chunked(into: samples.count / samplesCount)
+
+            for chunk in chunkedSamples {
+                let squaredSum = chunk.reduce(0) { $0 + $1 * $1 }
+                let averagePower = squaredSum / Float(chunk.count)
+                let decibels = 10 * log10(max(averagePower, Float.ulpOfOne))
+
+                let newAmplitude = 1.8 * pow(10.0, decibels / 20.0)
+                let clampedAmplitude = min(max(CGFloat(newAmplitude), 0), 1)
+                result.append(clampedAmplitude)
+            }
+
+            try? FileManager.default.removeItem(at: tempURL)
+
+            return result
+        } catch {
+            throw ASAudioErrors.analyzeError(reason: error.localizedDescription)
         }
-
-        try file.read(into: buffer)
-        guard let floatChannelData = buffer.floatChannelData else {
-            return []
-        }
-
-        let frameLength = Int(buffer.frameLength)
-        let samples = Array(UnsafeBufferPointer(start: floatChannelData[0], count: frameLength))
-        var result = [CGFloat]()
-        let chunkedSamples = samples.chunked(into: samples.count / samplesCount)
-
-        for chunk in chunkedSamples {
-            let squaredSum = chunk.reduce(0) { $0 + $1 * $1 }
-            let averagePower = squaredSum / Float(chunk.count)
-            let decibels = 10 * log10(max(averagePower, Float.ulpOfOne))
-
-            let newAmplitude = 1.8 * pow(10.0, decibels / 20.0)
-            let clampedAmplitude = min(max(CGFloat(newAmplitude), 0), 1)
-            result.append(clampedAmplitude)
-        }
-
-        try? FileManager.default.removeItem(at: tempURL)
-
-        return result
     }
 }
 

--- a/alsongDalsong/ASAudioKit/ASAudioErrors.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioErrors.swift
@@ -1,24 +1,19 @@
 import Foundation
 
-enum ASAudioErrors: Error, LocalizedError {
-    case startPlayingError(reason: String)
-    case getDurationError(reason: String)
-    case configureAudioSessionError(reason: String)
-    case startRecordingError(reason: String)
-    case analyzeError(reason: String)
+struct ASAudioErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
+
+    enum ErrorType {
+        case analyze
+        case startPlaying, getDuration
+        case configureAudioSession
+        case startRecording
+    }
 
     var errorDescription: String? {
-        switch self {
-        case .startPlayingError(let reason):
-            return "ASAudioPlayer.swift startPlaying() 에러: 오디오 객체 생성에 실패했습니다.\n\(reason)"
-        case .getDurationError(let reason):
-            return "ASAudioPlayer.swift getDuration() 에러: 오디오 객체 생성에 실패했습니다.\n\(reason)"
-        case .configureAudioSessionError(let reason):
-            return "confitureAudioSession() 에러: 세션 설정에 실패했습니다.\n\(reason)"
-        case .startRecordingError(let reason):
-            return "ASAudioRecorder.swift startRecording() 에러: 오디오 레코더 객체 생성에 실패했습니다.\n\(reason)"
-        case .analyzeError(let reason):
-            return "ASAudioAnalyzer.swift analyze() 에러: 오디오 분석에 실패했습니다.\n\(reason)"
-        }
+        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASAudioKit/ASAudioErrors.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioErrors.swift
@@ -14,6 +14,6 @@ struct ASAudioErrors: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
+        return "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASAudioKit/ASAudioErrors.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioErrors.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum ASAudioErrors: Error, LocalizedError {
+    case startPlayingError(reason: String)
+    case getDurationError(reason: String)
+    case configureAudioSessionError(reason: String)
+    case startRecordingError(reason: String)
+    case analyzeError(reason: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .startPlayingError(let reason):
+            return "ASAudioPlayer.swift startPlaying() 에러: 오디오 객체 생성에 실패했습니다.\n\(reason)"
+        case .getDurationError(let reason):
+            return "ASAudioPlayer.swift getDuration() 에러: 오디오 객체 생성에 실패했습니다.\n\(reason)"
+        case .configureAudioSessionError(let reason):
+            return "confitureAudioSession() 에러: 세션 설정에 실패했습니다.\n\(reason)"
+        case .startRecordingError(let reason):
+            return "ASAudioRecorder.swift startRecording() 에러: 오디오 레코더 객체 생성에 실패했습니다.\n\(reason)"
+        case .analyzeError(let reason):
+            return "ASAudioAnalyzer.swift analyze() 에러: 오디오 분석에 실패했습니다.\n\(reason)"
+        }
+    }
+}

--- a/alsongDalsong/ASAudioKit/ASAudioKit.xcodeproj/project.pbxproj
+++ b/alsongDalsong/ASAudioKit/ASAudioKit.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		4E8907C22CE2489A00D5B547 /* ASAudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E89071E2CE23D1B00D5B547 /* ASAudioKit.framework */; platformFilter = ios; };
 		4EB1ED372CE88E500012FFBA /* ASAudioKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E89071E2CE23D1B00D5B547 /* ASAudioKit.framework */; };
 		4EB1ED382CE88E500012FFBA /* ASAudioKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4E89071E2CE23D1B00D5B547 /* ASAudioKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		8593659D2D3F77FE0086C8C4 /* ASAudioErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8593659C2D3F77F60086C8C4 /* ASAudioErrors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +51,7 @@
 		4E89071E2CE23D1B00D5B547 /* ASAudioKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ASAudioKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E8907BE2CE2489A00D5B547 /* ASAudioKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ASAudioKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4EB1EC802CE7AA160012FFBA /* ASAudioDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ASAudioDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		8593659C2D3F77F60086C8C4 /* ASAudioErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASAudioErrors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -125,6 +127,7 @@
 			isa = PBXGroup;
 			children = (
 				1B7EB01A2CFDA83B00B2BE2A /* ASAudioAnalyzer.swift */,
+				8593659C2D3F77F60086C8C4 /* ASAudioErrors.swift */,
 				4E8907AD2CE240D400D5B547 /* ASAudioKit */,
 				4E8907BF2CE2489A00D5B547 /* ASAudioKitTests */,
 				4EB1EC812CE7AA160012FFBA /* ASAudioDemo */,
@@ -305,6 +308,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1B7EB01C2CFDA83B00B2BE2A /* ASAudioAnalyzer.swift in Sources */,
+				8593659D2D3F77FE0086C8C4 /* ASAudioErrors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioPlayer/ASAudioPlayer.swift
@@ -22,7 +22,7 @@ public actor ASAudioPlayer: NSObject {
             audioPlayer?.isMeteringEnabled = true
         } catch {
             // TODO: 오디오 객체생성 실패 시 처리
-            throw ASAudioErrors.startPlayingError(reason: error.localizedDescription)
+            throw ASAudioErrors(type: .startPlaying, reason: error.localizedDescription, file: #file, line: #line)
         }
 
         switch option {
@@ -58,7 +58,7 @@ public actor ASAudioPlayer: NSObject {
                 audioPlayer = try AVAudioPlayer(data: data)
             } catch {
                 // TODO: 오디오 객체생성 실패 시 처리
-                throw ASAudioErrors.getDurationError(reason: error.localizedDescription)
+                throw ASAudioErrors(type: .getDuration, reason: error.localizedDescription, file: #file, line: #line)
             }
         }
         return audioPlayer?.duration ?? 0
@@ -75,7 +75,7 @@ public actor ASAudioPlayer: NSObject {
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             // TODO: 세션 설정 실패에 따른 처리
-            throw ASAudioErrors.configureAudioSessionError(reason: error.localizedDescription)
+            throw ASAudioErrors(type: .configureAudioSession, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
@@ -5,33 +5,34 @@ public actor ASAudioRecorder {
 
     public init() {}
     /// 녹음 후 저장될 파일의 위치를 지정하여 녹음합니다.
-    public func startRecording(url: URL) {
-        configureAudioSession()
-        let settings = [
-            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
-            AVSampleRateKey: 12000,
-            AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
-        ]
-
+    public func startRecording(url: URL) throws {
         do {
+            try configureAudioSession()
+            let settings = [
+                AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+                AVSampleRateKey: 12000,
+                AVNumberOfChannelsKey: 1,
+                AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+            ]
             audioRecorder = try AVAudioRecorder(url: url, settings: settings)
             audioRecorder?.prepareToRecord()
             audioRecorder?.isMeteringEnabled = true
             audioRecorder?.record()
         } catch {
             // TODO: AVAudioRecorder 객체 생성 실패 시에 대한 처리
+            throw ASAudioErrors.startRecordingError(reason: error.localizedDescription)
         }
     }
 
     /// 오디오 세션을 설정합니다.
-    private func configureAudioSession() {
+    private func configureAudioSession() throws {
         do {
             let session = AVAudioSession.sharedInstance()
             try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             // TODO: 세션 설정 실패에 따른 처리
+            throw ASAudioErrors.configureAudioSessionError(reason: error.localizedDescription)
         }
     }
 

--- a/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
+++ b/alsongDalsong/ASAudioKit/ASAudioKit/ASAudioRecorder/ASAudioRecorder.swift
@@ -20,7 +20,7 @@ public actor ASAudioRecorder {
             audioRecorder?.record()
         } catch {
             // TODO: AVAudioRecorder 객체 생성 실패 시에 대한 처리
-            throw ASAudioErrors.startRecordingError(reason: error.localizedDescription)
+            throw ASAudioErrors(type: .startRecording, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 
@@ -32,7 +32,7 @@ public actor ASAudioRecorder {
             try session.setActive(true, options: .notifyOthersOnDeactivation)
         } catch {
             // TODO: 세션 설정 실패에 따른 처리
-            throw ASAudioErrors.configureAudioSessionError(reason: error.localizedDescription)
+            throw ASAudioErrors(type: .configureAudioSession, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 

--- a/alsongDalsong/ASDecoder/ASDecoder.xcodeproj/project.pbxproj
+++ b/alsongDalsong/ASDecoder/ASDecoder.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1B06307A2CE64E7C005300BF /* ASDecoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B702E612CE5193F00124F73 /* ASDecoder.framework */; };
 		1B06307B2CE64E7C005300BF /* ASDecoder.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B702E612CE5193F00124F73 /* ASDecoder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1B702E6A2CE5193F00124F73 /* ASDecoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B702E612CE5193F00124F73 /* ASDecoder.framework */; };
+		8593659A2D3F71E80086C8C4 /* ASDecoderErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859365982D3F71E40086C8C4 /* ASDecoderErrors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		1B06306B2CE64E74005300BF /* ASDecoderDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ASDecoderDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B702E612CE5193F00124F73 /* ASDecoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ASDecoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B702E692CE5193F00124F73 /* ASDecoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ASDecoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		859365982D3F71E40086C8C4 /* ASDecoderErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASDecoderErrors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -104,6 +106,7 @@
 		1B702E572CE5193F00124F73 = {
 			isa = PBXGroup;
 			children = (
+				859365982D3F71E40086C8C4 /* ASDecoderErrors.swift */,
 				1B702E632CE5193F00124F73 /* ASDecoder */,
 				1B702E6D2CE5193F00124F73 /* ASDecoderTests */,
 				1B06306C2CE64E74005300BF /* ASDecoderDemo */,
@@ -285,6 +288,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8593659A2D3F71E80086C8C4 /* ASDecoderErrors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/alsongDalsong/ASDecoder/ASDecoder/ASDecoder.swift
+++ b/alsongDalsong/ASDecoder/ASDecoder/ASDecoder.swift
@@ -2,11 +2,15 @@ import Foundation
 
 public enum ASDecoder {
     public static func decode<T: Decodable>(_: T.Type, from data: Data) throws -> T {
-        let decoder = JSONDecoder()
-        decoder.keyDecodingStrategy = .convertFromSnakeCase
-        decoder.dateDecodingStrategy = .iso8601
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            decoder.dateDecodingStrategy = .iso8601
 
-        return try decoder.decode(T.self, from: data)
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw ASDecoderErrors.decodeError(reason: error.localizedDescription)
+        }
     }
 
     public static func handleResponse<T: Decodable>(result: Result<Data, Error>) async throws -> T {

--- a/alsongDalsong/ASDecoder/ASDecoder/ASDecoder.swift
+++ b/alsongDalsong/ASDecoder/ASDecoder/ASDecoder.swift
@@ -9,7 +9,7 @@ public enum ASDecoder {
 
             return try decoder.decode(T.self, from: data)
         } catch {
-            throw ASDecoderErrors.decodeError(reason: error.localizedDescription)
+            throw ASDecoderErrors(type: .decode, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 

--- a/alsongDalsong/ASDecoder/ASDecoderErrors.swift
+++ b/alsongDalsong/ASDecoder/ASDecoderErrors.swift
@@ -1,12 +1,16 @@
 import Foundation
 
-enum ASDecoderErrors: Error, LocalizedError {
-    case decodeError(reason: String)
+struct ASDecoderErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
+
+    enum ErrorType {
+        case decode
+    }
 
     var errorDescription: String? {
-        switch self {
-            case .decodeError(let reason):
-                return "ASDecoder.swift decode() 에러: 데이터 디코딩 중 오류가 발생했습니다.\n\(reason)"
-        }
+        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASDecoder/ASDecoderErrors.swift
+++ b/alsongDalsong/ASDecoder/ASDecoderErrors.swift
@@ -11,6 +11,6 @@ struct ASDecoderErrors: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
+        return "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASDecoder/ASDecoderErrors.swift
+++ b/alsongDalsong/ASDecoder/ASDecoderErrors.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum ASDecoderErrors: Error, LocalizedError {
+    case decodeError(reason: String)
+
+    var errorDescription: String? {
+        switch self {
+            case .decodeError(let reason):
+                return "ASDecoder.swift decode() 에러: 데이터 디코딩 중 오류가 발생했습니다.\n\(reason)"
+        }
+    }
+}

--- a/alsongDalsong/ASEncoder/ASEncoder.xcodeproj/project.pbxproj
+++ b/alsongDalsong/ASEncoder/ASEncoder.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1B1327F02CE5F26400EF706D /* ASEncoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B702E2F2CE5152600124F73 /* ASEncoder.framework */; };
 		1B1327F12CE5F26400EF706D /* ASEncoder.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1B702E2F2CE5152600124F73 /* ASEncoder.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1B702E382CE5152600124F73 /* ASEncoder.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B702E2F2CE5152600124F73 /* ASEncoder.framework */; };
+		859365972D3F71390086C8C4 /* ASEncoderErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859365952D3F71310086C8C4 /* ASEncoderErrors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +48,7 @@
 		1B702E2F2CE5152600124F73 /* ASEncoder.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ASEncoder.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B702E372CE5152600124F73 /* ASEncoderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ASEncoderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1BDDABBD2CE5E2E000147881 /* ASEncoderDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ASEncoderDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		859365952D3F71310086C8C4 /* ASEncoderErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASEncoderErrors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -104,6 +106,7 @@
 		1B702E252CE5152600124F73 = {
 			isa = PBXGroup;
 			children = (
+				859365952D3F71310086C8C4 /* ASEncoderErrors.swift */,
 				1B702E312CE5152600124F73 /* ASEncoder */,
 				1B702E3B2CE5152600124F73 /* ASEncoderTests */,
 				1BDDABBE2CE5E2E000147881 /* ASEncoderDemo */,
@@ -278,6 +281,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				859365972D3F71390086C8C4 /* ASEncoderErrors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/alsongDalsong/ASEncoder/ASEncoder/ASEncoder.swift
+++ b/alsongDalsong/ASEncoder/ASEncoder/ASEncoder.swift
@@ -10,7 +10,7 @@ public enum ASEncoder {
 
             return try encoder.encode(value)
         } catch {
-            throw ASEncoderErrors.encodeError(reason: error.localizedDescription)
+            throw ASEncoderErrors(type: .encode, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASEncoder/ASEncoder/ASEncoder.swift
+++ b/alsongDalsong/ASEncoder/ASEncoder/ASEncoder.swift
@@ -2,11 +2,15 @@ import Foundation
 
 public enum ASEncoder {
     public static func encode<T: Encodable>(_ value: T) throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.keyEncodingStrategy = .useDefaultKeys
-        encoder.outputFormatting = [.prettyPrinted]
+        do {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.keyEncodingStrategy = .useDefaultKeys
+            encoder.outputFormatting = [.prettyPrinted]
 
-        return try encoder.encode(value)
+            return try encoder.encode(value)
+        } catch {
+            throw ASEncoderErrors.encodeError(reason: error.localizedDescription)
+        }
     }
 }

--- a/alsongDalsong/ASEncoder/ASEncoderErrors.swift
+++ b/alsongDalsong/ASEncoder/ASEncoderErrors.swift
@@ -1,12 +1,16 @@
 import Foundation
 
-enum ASEncoderErrors: Error, LocalizedError {
-    case encodeError(reason: String)
+struct ASEncoderErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
+
+    enum ErrorType {
+        case encode
+    }
 
     var errorDescription: String? {
-        switch self {
-            case .encodeError(let reason):
-                return "ASEncoder.swift encode() 에러: 데이터 인코딩 중 오류가 발생했습니다.\n\(reason)"
-        }
+        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASEncoder/ASEncoderErrors.swift
+++ b/alsongDalsong/ASEncoder/ASEncoderErrors.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum ASEncoderErrors: Error, LocalizedError {
+    case encodeError(reason: String)
+
+    var errorDescription: String? {
+        switch self {
+            case .encodeError(let reason):
+                return "ASEncoder.swift encode() 에러: 데이터 인코딩 중 오류가 발생했습니다.\n\(reason)"
+        }
+    }
+}

--- a/alsongDalsong/ASEncoder/ASEncoderErrors.swift
+++ b/alsongDalsong/ASEncoder/ASEncoderErrors.swift
@@ -11,6 +11,6 @@ struct ASEncoderErrors: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
+        return "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASMusicKit/ASMusicErrors.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicErrors.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+enum ASMusicErrors: Error, LocalizedError {
+    case notAuthorized
+    case searchError(reason: String)
+    case playListHasNoSongs
+
+    var errorDescription: String? {
+        switch self {
+            case .notAuthorized:
+                return "ASMusicAPI.swift search() 에러: 애플 뮤직에 접근하는 권한이 없습니다."
+            case .searchError(let reason):
+                return "ASMusicAPI.swift search() 에러: 노래 검색 중 오류가 발생했습니다.\n\(reason)"
+            case .playListHasNoSongs:
+                return "ASMusicAPI.swift randomSong() 에러: 플레이리스트에 노래가 없습니다."
+        }
+    }
+}

--- a/alsongDalsong/ASMusicKit/ASMusicErrors.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicErrors.swift
@@ -1,18 +1,19 @@
 import Foundation
 
-enum ASMusicErrors: Error, LocalizedError {
-    case notAuthorized
-    case searchError(reason: String)
-    case playListHasNoSongs
+struct ASMusicErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
+
+    enum ErrorType {
+        case notAuthorized
+        case search
+        case playListHasNoSongs
+    }
 
     var errorDescription: String? {
-        switch self {
-            case .notAuthorized:
-                return "ASMusicAPI.swift search() 에러: 애플 뮤직에 접근하는 권한이 없습니다."
-            case .searchError(let reason):
-                return "ASMusicAPI.swift search() 에러: 노래 검색 중 오류가 발생했습니다.\n\(reason)"
-            case .playListHasNoSongs:
-                return "ASMusicAPI.swift randomSong() 에러: 플레이리스트에 노래가 없습니다."
-        }
+        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
     }
 }
+

--- a/alsongDalsong/ASMusicKit/ASMusicErrors.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicErrors.swift
@@ -13,7 +13,7 @@ struct ASMusicErrors: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
+        return "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \n\(reason)"
     }
 }
 

--- a/alsongDalsong/ASMusicKit/ASMusicKit.xcodeproj/project.pbxproj
+++ b/alsongDalsong/ASMusicKit/ASMusicKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		859365942D3F709D0086C8C4 /* ASMusicErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859365912D3F70960086C8C4 /* ASMusicErrors.swift */; };
 		8D7F5A862CF88C32002EAB0F /* ASEntity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D7F5A852CF88C25002EAB0F /* ASEntity.framework */; };
 		8D7F5A872CF88C32002EAB0F /* ASEntity.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8D7F5A852CF88C25002EAB0F /* ASEntity.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -37,6 +38,7 @@
 
 /* Begin PBXFileReference section */
 		1635A4282CE59833002246E0 /* ASMusicKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ASMusicKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		859365912D3F70960086C8C4 /* ASMusicErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ASMusicErrors.swift; sourceTree = "<group>"; };
 		8D7F5A802CF88C25002EAB0F /* ASEntity.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ASEntity.xcodeproj; path = ../ASEntity/ASEntity.xcodeproj; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -79,6 +81,7 @@
 		8D9402E22CE37DA1009D21C4 = {
 			isa = PBXGroup;
 			children = (
+				859365912D3F70960086C8C4 /* ASMusicErrors.swift */,
 				8D4F31732CE3805D00E13720 /* ASMusicKit */,
 				1635A4282CE59833002246E0 /* ASMusicKit.framework */,
 				8D7F5A7F2CF88C25002EAB0F /* Frameworks */,
@@ -186,6 +189,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				859365942D3F709D0086C8C4 /* ASMusicErrors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -55,10 +55,10 @@ public struct ASMusicAPI {
                         return music
                     }
                 } catch {
-                    throw ASMusicErrors.searchError(reason: error.localizedDescription)
+                    throw ASMusicErrors(type: .search, reason: error.localizedDescription, file: #file, line: #line)
                 }
             default:
-                throw ASMusicErrors.notAuthorized
+            throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
         }
     }
 
@@ -73,7 +73,7 @@ public struct ASMusicAPI {
 
                     let playlistWithTrack = try await playlist.with([.tracks])
                     guard let tracks = playlistWithTrack.tracks else {
-                        throw ASMusicErrors.playListHasNoSongs
+                        throw ASMusicErrors(type: .playListHasNoSongs, reason: "", file: #file, line: #line)
                     }
 
                     if let song = tracks.randomElement() {
@@ -87,10 +87,10 @@ public struct ASMusicAPI {
                         )
                     }
                 } catch {
-                    throw ASMusicErrors.playListHasNoSongs
+                    throw ASMusicErrors(type: .search, reason: "", file: #file, line: #line)
                 }
             default:
-                throw ASMusicErrors.notAuthorized
+            throw ASMusicErrors(type: .notAuthorized, reason: "", file: #file, line: #line)
         }
         return ASEntity.Music(id: "nil", title: nil, artist: nil, artworkUrl: nil, previewUrl: nil, artworkBackgroundColor: nil)
     }

--- a/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
+++ b/alsongDalsong/ASMusicKit/ASMusicKit/ASMusicAPI.swift
@@ -55,10 +55,10 @@ public struct ASMusicAPI {
                         return music
                     }
                 } catch {
-                    throw ASMusicError.searchError
+                    throw ASMusicErrors.searchError(reason: error.localizedDescription)
                 }
             default:
-                throw ASMusicError.notAuthorized
+                throw ASMusicErrors.notAuthorized
         }
     }
 
@@ -73,7 +73,7 @@ public struct ASMusicAPI {
 
                     let playlistWithTrack = try await playlist.with([.tracks])
                     guard let tracks = playlistWithTrack.tracks else {
-                        throw ASMusicError.playListHasNoSongs
+                        throw ASMusicErrors.playListHasNoSongs
                     }
 
                     if let song = tracks.randomElement() {
@@ -87,28 +87,11 @@ public struct ASMusicAPI {
                         )
                     }
                 } catch {
-                    throw ASMusicError.playListHasNoSongs
+                    throw ASMusicErrors.playListHasNoSongs
                 }
             default:
-                throw ASMusicError.notAuthorized
+                throw ASMusicErrors.notAuthorized
         }
         return ASEntity.Music(id: "nil", title: nil, artist: nil, artworkUrl: nil, previewUrl: nil, artworkBackgroundColor: nil)
-    }
-}
-
-enum ASMusicError: Error, LocalizedError {
-    case notAuthorized
-    case searchError
-    case playListHasNoSongs
-
-    var errorDescription: String? {
-        switch self {
-            case .notAuthorized:
-                "애플 뮤직에 접근하는 권한이 없습니다."
-            case .searchError:
-                "노래 검색 중 오류가 발생했습니다."
-            case .playListHasNoSongs:
-                "플레이리스트에 노래가 없습니다."
-        }
     }
 }

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
@@ -1,30 +1,29 @@
 import Foundation
 
-public enum ASNetworkErrors: Error, LocalizedError {
-    case serverError(message: String)
-    case urlError
-    case getAvatarUrlsError(reason: String)
-    case FirebaseSignInError(reason: String)
-    case FirebaseSignOutError(reason: String)
-    case FirebaseListenerError(reason: String?)
-    case responseError
+public struct ASNetworkErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
+
+    public init(type: ErrorType, reason: String, file: String, line: Int) {
+        self.type = type
+        self.reason = reason
+        self.file = file
+        self.line = line
+    }
+
+    public enum ErrorType {
+        case serverError
+        case urlError
+        case getAvatarUrls
+        case firebaseSignIn, firebaseSignOut
+        case firebaseListener
+        case responseError
+    }
 
     public var errorDescription: String? {
-        switch self {
-            case let .serverError(message: message):
-                return message
-            case .urlError:
-                return "ASNetworkManager.swift URL 에러: URL이 제대로 입력되지 않았습니다."
-            case .getAvatarUrlsError(let reason):
-                return "ASFirebaseStorage.swift getAvatarUrls() 에러: 서버에서 응답이 없거나 잘못된 응답이 왔습니다.\n\(reason)"
-            case .FirebaseSignInError(let reason):
-                return "ASFirebaseAuth.swift signIn() 에러: 익명 로그인에 실패했습니다.\n\(reason)"
-            case .FirebaseSignOutError(let reason):
-                return "ASFirebaseAuth.swift signOut() 에러: 로그아웃에 실패했습니다.\n\(reason)"
-            case .FirebaseListenerError(let reason):
-                return "ASFirebaseDatabase.swift addRoomListener() 에러: 해당 데이터베이스를 가져오는데 실패했습니다.\n\(reason ?? "")"
-            case .responseError:
-                return "ASNetworkManager.swift validate() 에러: 서버에서 응답이 없거나 잘못된 응답이 왔습니다."
-        }
+        return "[\(file):\(line)] \(type) 에러: \(reason)"
     }
 }
+

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
@@ -23,7 +23,7 @@ public struct ASNetworkErrors: LocalizedError {
     }
 
     public var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \(reason)"
+        return "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \(reason)"
     }
 }
 

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkErrors.swift
@@ -3,25 +3,28 @@ import Foundation
 public enum ASNetworkErrors: Error, LocalizedError {
     case serverError(message: String)
     case urlError
+    case getAvatarUrlsError(reason: String)
+    case FirebaseSignInError(reason: String)
+    case FirebaseSignOutError(reason: String)
+    case FirebaseListenerError(reason: String?)
     case responseError
-    case FirebaseSignInError
-    case FirebaseSignOutError
-    case FirebaseListenerError
-    
+
     public var errorDescription: String? {
         switch self {
             case let .serverError(message: message):
                 return message
             case .urlError:
-                return "URL에러: URL이 제대로 입력되지 않았습니다."
+                return "ASNetworkManager.swift URL 에러: URL이 제대로 입력되지 않았습니다."
+            case .getAvatarUrlsError(let reason):
+                return "ASFirebaseStorage.swift getAvatarUrls() 에러: 서버에서 응답이 없거나 잘못된 응답이 왔습니다.\n\(reason)"
+            case .FirebaseSignInError(let reason):
+                return "ASFirebaseAuth.swift signIn() 에러: 익명 로그인에 실패했습니다.\n\(reason)"
+            case .FirebaseSignOutError(let reason):
+                return "ASFirebaseAuth.swift signOut() 에러: 로그아웃에 실패했습니다.\n\(reason)"
+            case .FirebaseListenerError(let reason):
+                return "ASFirebaseDatabase.swift addRoomListener() 에러: 해당 데이터베이스를 가져오는데 실패했습니다.\n\(reason ?? "")"
             case .responseError:
-                return "응답 에러: 서버에서 응답이 없거나 잘못된 응답이 왔습니다."
-            case .FirebaseSignInError:
-                return "파이어베이스 에러: 익명 로그인에 실패했습니다."
-            case .FirebaseSignOutError:
-                return "파이어베이스 에러: 로그아웃에 실패했습니다."
-            case .FirebaseListenerError:
-                return "파이어베이스 에러: 해당 데이터베이스를 가져오는데 실패했습니다."
+                return "ASNetworkManager.swift validate() 에러: 서버에서 응답이 없거나 잘못된 응답이 왔습니다."
         }
     }
 }

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkManager.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/ASNetworkManager.swift
@@ -17,7 +17,9 @@ struct ASNetworkManager: ASNetworkManagerProtocol {
         body: Data? = nil,
         option: CacheOption = .both
     ) async throws -> Data {
-        guard let url = endpoint.url else { throw ASNetworkErrors.urlError }
+        guard let url = endpoint.url else {
+            throw ASNetworkErrors(type: .urlError, reason: "", file: #file, line: #line)
+        }
         if let cache = try await loadCache(from: url, option: option) { return cache }
 
         let updatedEndpoint = updateEndpoint(type: type, endpoint: endpoint, body: body)
@@ -45,7 +47,9 @@ struct ASNetworkManager: ASNetworkManagerProtocol {
     }
 
     private func urlRequest(for endpoint: any Endpoint) throws -> URLRequest {
-        guard let url = endpoint.url else { throw ASNetworkErrors.urlError }
+        guard let url = endpoint.url else {
+            throw ASNetworkErrors(type: .urlError, reason: "", file: #file, line: #line)
+        }
         return RequestBuilder(using: url)
             .setHeader(endpoint.headers)
             .setHttpMethod(endpoint.method)
@@ -55,7 +59,7 @@ struct ASNetworkManager: ASNetworkManagerProtocol {
 
     private func validate(response: URLResponse) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
-            throw ASNetworkErrors.responseError
+            throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
         }
 
         let statusCode = StatusCode(statusCode: httpResponse.statusCode)
@@ -63,7 +67,7 @@ struct ASNetworkManager: ASNetworkManagerProtocol {
             case .success, .noContent:
                 break
             default:
-                throw ASNetworkErrors.serverError(message: statusCode.description)
+            throw ASNetworkErrors(type: .serverError, reason: "", file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseAuth.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseAuth.swift
@@ -11,7 +11,7 @@ public final class ASFirebaseAuth: ASFirebaseAuthProtocol {
     public func signIn(nickname: String, avatarURL: URL?) async throws {
         do {
             guard let myID = ASFirebaseAuth.myID else {
-                throw ASNetworkErrors.FirebaseSignInError(reason: "ASFirebaseAuth.myID is nil")
+                throw ASNetworkErrors(type: .firebaseSignIn, reason: "ASFirebaseAuth.myID is nil", file: #file, line: #line)
             }
             let player = Player(id: myID, avatarUrl: avatarURL, nickname: nickname, order: 0)
             let playerData = try ASEncoder.encode(player)
@@ -26,19 +26,19 @@ public final class ASFirebaseAuth: ASFirebaseAuthProtocol {
                 }
             }
         } catch {
-            throw ASNetworkErrors.FirebaseSignInError(reason: error.localizedDescription)
+            throw ASNetworkErrors(type: .firebaseSignIn, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 
     public func signOut() async throws {
         do {
             guard let userID = ASFirebaseAuth.myID else {
-                throw ASNetworkErrors.FirebaseSignOutError(reason: "ASFirebaseAuth.myID is nil")
+                throw ASNetworkErrors(type: .firebaseSignOut, reason: "ASFirebaseAuth.myID is nil", file: #file, line: #line)
             }
             try await databaseRef.child("players").child(userID).removeValue()
             try Auth.auth().signOut()
         } catch {
-            throw ASNetworkErrors.FirebaseSignOutError(reason: error.localizedDescription)
+            throw ASNetworkErrors(type: .firebaseSignOut, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseAuth.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseAuth.swift
@@ -10,7 +10,9 @@ public final class ASFirebaseAuth: ASFirebaseAuthProtocol {
 
     public func signIn(nickname: String, avatarURL: URL?) async throws {
         do {
-            guard let myID = ASFirebaseAuth.myID else { throw ASNetworkErrors.FirebaseSignInError }
+            guard let myID = ASFirebaseAuth.myID else {
+                throw ASNetworkErrors.FirebaseSignInError(reason: "ASFirebaseAuth.myID is nil")
+            }
             let player = Player(id: myID, avatarUrl: avatarURL, nickname: nickname, order: 0)
             let playerData = try ASEncoder.encode(player)
             let dict = try JSONSerialization.jsonObject(with: playerData, options: .allowFragments) as? [String: Any]
@@ -24,17 +26,19 @@ public final class ASFirebaseAuth: ASFirebaseAuthProtocol {
                 }
             }
         } catch {
-            throw ASNetworkErrors.FirebaseSignInError
+            throw ASNetworkErrors.FirebaseSignInError(reason: error.localizedDescription)
         }
     }
 
     public func signOut() async throws {
         do {
-            guard let userID = ASFirebaseAuth.myID else { throw ASNetworkErrors.FirebaseSignOutError }
+            guard let userID = ASFirebaseAuth.myID else {
+                throw ASNetworkErrors.FirebaseSignOutError(reason: "ASFirebaseAuth.myID is nil")
+            }
             try await databaseRef.child("players").child(userID).removeValue()
             try Auth.auth().signOut()
         } catch {
-            throw ASNetworkErrors.FirebaseSignOutError
+            throw ASNetworkErrors.FirebaseSignOutError(reason: error.localizedDescription)
         }
     }
 

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseDatabase.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseDatabase.swift
@@ -15,14 +15,14 @@ final class ASFirebaseDatabase: ASFirebaseDatabaseProtocol {
             }
             
             guard let document = documentSnapshot, document.exists else {
-                return self.roomPublisher.send(completion: .failure(ASNetworkErrors.FirebaseListenerError))
+                return self.roomPublisher.send(completion: .failure(ASNetworkErrors.FirebaseListenerError(reason: error?.localizedDescription)))
             }
             
             do {
                 let room = try document.data(as: Room.self)
                 return self.roomPublisher.send(room)
             } catch {
-                return self.roomPublisher.send(completion: .failure(ASNetworkErrors.FirebaseListenerError))
+                return self.roomPublisher.send(completion: .failure(ASNetworkErrors.FirebaseListenerError(reason: error.localizedDescription)))
             }
         }
         

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseDatabase.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseDatabase.swift
@@ -15,14 +15,14 @@ final class ASFirebaseDatabase: ASFirebaseDatabaseProtocol {
             }
             
             guard let document = documentSnapshot, document.exists else {
-                return self.roomPublisher.send(completion: .failure(ASNetworkErrors.FirebaseListenerError(reason: error?.localizedDescription)))
+                return self.roomPublisher.send(completion: .failure(ASNetworkErrors(type: .firebaseListener, reason: error?.localizedDescription ?? "", file: #file, line: #line)))
             }
             
             do {
                 let room = try document.data(as: Room.self)
                 return self.roomPublisher.send(room)
             } catch {
-                return self.roomPublisher.send(completion: .failure(ASNetworkErrors.FirebaseListenerError(reason: error.localizedDescription)))
+                return self.roomPublisher.send(completion: .failure(ASNetworkErrors(type: .firebaseListener, reason: error.localizedDescription, file: #file, line: #line)))
             }
         }
         

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseStorage.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseStorage.swift
@@ -10,7 +10,7 @@ final class ASFirebaseStorage: ASFirebaseStorageProtocol {
             let result = try await avatarRef.listAll()
             return try await fetchDownloadURLs(from: result.items)
         } catch {
-            throw ASNetworkErrors.getAvatarUrlsError(reason: error.localizedDescription)
+            throw ASNetworkErrors(type: .getAvatarUrls, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     

--- a/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseStorage.swift
+++ b/alsongDalsong/ASNetworkKit/ASNetworkKit/Firebase/ASFirebaseStorage.swift
@@ -10,7 +10,7 @@ final class ASFirebaseStorage: ASFirebaseStorageProtocol {
             let result = try await avatarRef.listAll()
             return try await fetchDownloadURLs(from: result.items)
         } catch {
-            throw ASNetworkErrors.responseError
+            throw ASNetworkErrors.getAvatarUrlsError(reason: error.localizedDescription)
         }
     }
     

--- a/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
+++ b/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
@@ -1,52 +1,21 @@
 import Foundation
 
-enum ASRepositoryErrors: Error, LocalizedError {
-    case submitMusicError(reason: String)
-    case getAvatarUrlsError(reason: String)
-    case postRecordingError(reason: String)
-    case postResetGameError(reason: String)
-    case uploadRecordingError(reason: String)
-    case createRoomError(reason: String)
-    case joinRoomError(reason: String)
-    case leaveRoomError(reason: String)
-    case startGameError(reason: String)
-    case changeModeError(reason: String)
-    case changeRecordOrderError(reason: String)
-    case resetGameError(reason: String)
-    case sendRequestError(reason: String)
-    case submitAnswerError(reason: String)
+struct ASRepositoryErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
 
+    enum ErrorType {
+        case submitMusic
+        case getAvatarUrls
+        case postRecording, postResetGame
+        case uploadRecording
+        case createRoom, joinRoom, leaveRoom, startGame, changeMode, changeRecordOrder, resetGame, sendRequest
+        case submitAnswer
+    }
 
     var errorDescription: String? {
-        switch self {
-        case .submitMusicError(let reason):
-            return "AnswersRepository.swift submitMusic() 에러: \n\(reason)"
-        case .getAvatarUrlsError(let reason):
-            return "AvatarRepository.swift getAvatarUrls() 에러: \n\(reason)"
-        case .postRecordingError(let reason):
-            return "MainRepository.swift postRecording() 에러: \n\(reason)"
-        case .postResetGameError(let reason):
-            return "MainRepository.swift postResetGame() 에러: \n\(reason)"
-        case .uploadRecordingError(let reason):
-            return "RecordsRepository.swift uploadRecording() 에러: \n\(reason)"
-        case .createRoomError(let reason):
-            return "RoomActionRepository.swift createRoom() 에러: \n\(reason)"
-        case .joinRoomError(let reason):
-            return "RoomActionRepository.swift joinRoom() 에러: \n\(reason)"
-        case .leaveRoomError(let reason):
-            return "RoomActionRepository.swift leaveRoom() 에러: \n\(reason)"
-        case .startGameError(let reason):
-            return "RoomActionRepository.swift startGame() 에러: \n\(reason)"
-        case .changeModeError(let reason):
-            return "RoomActionRepository.swift changeMode() 에러: \n\(reason)"
-        case .changeRecordOrderError(let reason):
-            return "RoomActionRepository.swift changeRecordOrder() 에러: \n\(reason)"
-        case .resetGameError(let reason):
-            return "RoomActionRepository.swift resetGame() 에러: \n\(reason)"
-        case .sendRequestError(let reason):
-            return "RoomActionRepository.swift sendRequest() 에러: \n\(reason)"
-        case .submitAnswerError(let reason):
-            return "SubmitsRepository.swift submitAnswer() 에러: \n\(reason)"
-        }
+        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
+++ b/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+enum ASRepositoryErrors: Error, LocalizedError {
+    case submitMusicError(reason: String)
+    case getAvatarUrlsError(reason: String)
+    case postRecordingError(reason: String)
+    case postResetGameError(reason: String)
+    case uploadRecordingError(reason: String)
+    case createRoomError(reason: String)
+    case joinRoomError(reason: String)
+    case leaveRoomError(reason: String)
+    case startGameError(reason: String)
+    case changeModeError(reason: String)
+    case changeRecordOrderError(reason: String)
+    case resetGameError(reason: String)
+    case sendRequestError(reason: String)
+    case submitAnswerError(reason: String)
+
+
+    var errorDescription: String? {
+        switch self {
+        case .submitMusicError(let reason):
+            return "AnswersRepository.swift submitMusic() 에러: \n\(reason)"
+        case .getAvatarUrlsError(let reason):
+            return "AvatarRepository.swift getAvatarUrls() 에러: \n\(reason)"
+        case .postRecordingError(let reason):
+            return "MainRepository.swift postRecording() 에러: \n\(reason)"
+        case .postResetGameError(let reason):
+            return "MainRepository.swift postResetGame() 에러: \n\(reason)"
+        case .uploadRecordingError(let reason):
+            return "RecordsRepository.swift uploadRecording() 에러: \n\(reason)"
+        case .createRoomError(let reason):
+            return "RoomActionRepository.swift createRoom() 에러: \n\(reason)"
+        case .joinRoomError(let reason):
+            return "RoomActionRepository.swift joinRoom() 에러: \n\(reason)"
+        case .leaveRoomError(let reason):
+            return "RoomActionRepository.swift leaveRoom() 에러: \n\(reason)"
+        case .startGameError(let reason):
+            return "RoomActionRepository.swift startGame() 에러: \n\(reason)"
+        case .changeModeError(let reason):
+            return "RoomActionRepository.swift changeMode() 에러: \n\(reason)"
+        case .changeRecordOrderError(let reason):
+            return "RoomActionRepository.swift changeRecordOrder() 에러: \n\(reason)"
+        case .resetGameError(let reason):
+            return "RoomActionRepository.swift resetGame() 에러: \n\(reason)"
+        case .sendRequestError(let reason):
+            return "RoomActionRepository.swift sendRequest() 에러: \n\(reason)"
+        case .submitAnswerError(let reason):
+            return "SubmitsRepository.swift submitAnswer() 에러: \n\(reason)"
+        }
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
+++ b/alsongDalsong/ASRepository/ASRepository/ASRepositoryErrors.swift
@@ -16,6 +16,6 @@ struct ASRepositoryErrors: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
+        return "[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
@@ -38,14 +38,18 @@ final class AnswersRepository: AnswersRepositoryProtocol {
     }
 
     func submitMusic(answer: ASEntity.Music) async throws -> Bool {
-        let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
-                          URLQueryItem(name: "roomNumber", value: mainRepository.number.value)]
-        let endPoint = FirebaseEndpoint(path: .submitMusic, method: .post)
-            .update(\.queryItems, with: queryItems)
+        do {
+            let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
+                              URLQueryItem(name: "roomNumber", value: mainRepository.number.value)]
+            let endPoint = FirebaseEndpoint(path: .submitMusic, method: .post)
+                .update(\.queryItems, with: queryItems)
 
-        let body = try ASEncoder.encode(answer)
-        let response = try await networkManager.sendRequest(to: endPoint, type: .json, body: body, option: .none)
-        let responseDict = try ASDecoder.decode([String: String].self, from: response)
-        return !responseDict.isEmpty
+            let body = try ASEncoder.encode(answer)
+            let response = try await networkManager.sendRequest(to: endPoint, type: .json, body: body, option: .none)
+            let responseDict = try ASDecoder.decode([String: String].self, from: response)
+            return !responseDict.isEmpty
+        } catch {
+            throw ASRepositoryErrors.submitMusicError(reason: error.localizedDescription)
+        }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/AnswersRepository.swift
@@ -49,7 +49,7 @@ final class AnswersRepository: AnswersRepositoryProtocol {
             let responseDict = try ASDecoder.decode([String: String].self, from: response)
             return !responseDict.isEmpty
         } catch {
-            throw ASRepositoryErrors.submitMusicError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .submitMusic, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/AvatarRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/AvatarRepository.swift
@@ -18,7 +18,7 @@ final class AvatarRepository: AvatarRepositoryProtocol {
             let urls = try await self.storageManager.getAvatarUrls()
             return urls
         } catch {
-            throw error
+            throw ASRepositoryErrors.getAvatarUrlsError(reason: error.localizedDescription)
         }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/AvatarRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/AvatarRepository.swift
@@ -18,7 +18,7 @@ final class AvatarRepository: AvatarRepositoryProtocol {
             let urls = try await self.storageManager.getAvatarUrls()
             return urls
         } catch {
-            throw ASRepositoryErrors.getAvatarUrlsError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .getAvatarUrls, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/DataDownloadRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/DataDownloadRepository.swift
@@ -1,3 +1,4 @@
+import ASLogKit
 import ASNetworkKit
 import ASRepositoryProtocol
 
@@ -14,6 +15,7 @@ final class DataDownloadRepository: DataDownloadRepositoryProtocol {
             let data = try await networkManager.sendRequest(to: endpoint, type: .none, body: nil, option: .both)
             return data
         } catch {
+            Logger.error("DataDownloadRepository.swift downloadData() 에러: \n\(error.localizedDescription)")
             return nil
         }
     }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -102,7 +102,7 @@ final class MainRepository: MainRepositoryProtocol {
             guard let success = responseDict["success"] else { return false }
             return success
         } catch {
-            throw ASRepositoryErrors.postRecordingError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .postRecording, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -124,7 +124,7 @@ final class MainRepository: MainRepositoryProtocol {
             guard let success = responseDict["success"] else { return false }
             return success
         } catch {
-            throw ASRepositoryErrors.postResetGameError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .postResetGame, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/MainRepository.swift
@@ -86,37 +86,45 @@ final class MainRepository: MainRepositoryProtocol {
     }
 
     func postRecording(_ record: Data) async throws -> Bool {
-        let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
-                          URLQueryItem(name: "roomNumber", value: number.value)]
-        let endPoint = FirebaseEndpoint(path: .uploadRecording, method: .post)
-            .update(\.queryItems, with: queryItems)
+        do {
+            let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
+                              URLQueryItem(name: "roomNumber", value: number.value)]
+            let endPoint = FirebaseEndpoint(path: .uploadRecording, method: .post)
+                .update(\.queryItems, with: queryItems)
 
-        let response = try await networkManager.sendRequest(
-            to: endPoint,
-            type: .multipart,
-            body: record,
-            option: .none
-        )
-        let responseDict = try ASDecoder.decode([String: Bool].self, from: response)
-        guard let success = responseDict["success"] else { return false }
-        return success
+            let response = try await networkManager.sendRequest(
+                to: endPoint,
+                type: .multipart,
+                body: record,
+                option: .none
+            )
+            let responseDict = try ASDecoder.decode([String: Bool].self, from: response)
+            guard let success = responseDict["success"] else { return false }
+            return success
+        } catch {
+            throw ASRepositoryErrors.postRecordingError(reason: error.localizedDescription)
+        }
     }
     
     func postResetGame() async throws -> Bool {
-        let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
-                          URLQueryItem(name: "roomNumber", value: number.value)]
-        let endPoint = FirebaseEndpoint(path: .resetGame, method: .post)
-            .update(\.queryItems, with: queryItems)
+        do {
+            let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
+                              URLQueryItem(name: "roomNumber", value: number.value)]
+            let endPoint = FirebaseEndpoint(path: .resetGame, method: .post)
+                .update(\.queryItems, with: queryItems)
 
-        let response = try await networkManager.sendRequest(
-            to: endPoint,
-            type: .none,
-            body: nil,
-            option: .none
-        )
-        
-        let responseDict = try ASDecoder.decode([String: Bool].self, from: response)
-        guard let success = responseDict["success"] else { return false }
-        return success
+            let response = try await networkManager.sendRequest(
+                to: endPoint,
+                type: .none,
+                body: nil,
+                option: .none
+            )
+
+            let responseDict = try ASDecoder.decode([String: Bool].self, from: response)
+            guard let success = responseDict["success"] else { return false }
+            return success
+        } catch {
+            throw ASRepositoryErrors.postResetGameError(reason: error.localizedDescription)
+        }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RecordsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RecordsRepository.swift
@@ -40,7 +40,11 @@ final class RecordsRepository: RecordsRepositoryProtocol {
     }
 
     func uploadRecording(_ record: Data) async throws -> Bool {
-        return try await mainRepository.postRecording(record)
+        do {
+            return try await mainRepository.postRecording(record)
+        } catch {
+            throw ASRepositoryErrors.uploadRecordingError(reason: error.localizedDescription)
+        }
     }
     
     private func findRecord(records: [ASEntity.Record]?,

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RecordsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RecordsRepository.swift
@@ -43,7 +43,7 @@ final class RecordsRepository: RecordsRepositoryProtocol {
         do {
             return try await mainRepository.postRecording(record)
         } catch {
-            throw ASRepositoryErrors.uploadRecordingError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .uploadRecording, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/RoomActionRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/RoomActionRepository.swift
@@ -27,11 +27,11 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 requestBody: ["hostID": ASFirebaseAuth.myID]
             )
             guard let roomNumber = response?["number"] as? String else {
-                throw ASNetworkErrors.responseError
+                throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return roomNumber
         } catch {
-            throw ASRepositoryErrors.createRoomError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .createRoom, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -43,11 +43,11 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 requestBody: ["roomNumber": roomNumber, "userId": ASFirebaseAuth.myID]
             )
             guard let roomNumberResponse = response?["number"] as? String else {
-                throw ASNetworkErrors.responseError
+                throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return roomNumberResponse == roomNumber
         } catch {
-            throw ASRepositoryErrors.joinRoomError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .joinRoom, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -57,7 +57,7 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
             try await self.authManager.signOut()
             return true
         } catch {
-            throw ASRepositoryErrors.leaveRoomError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .leaveRoom, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -68,11 +68,11 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 requestBody: ["roomNumber": roomNumber, "userId": ASFirebaseAuth.myID]
             )
             guard let response = response?["success"] as? Bool else {
-                throw ASNetworkErrors.responseError
+                throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return response
         } catch {
-            throw ASRepositoryErrors.startGameError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .startGame, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -83,11 +83,11 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 requestBody: ["roomNumber": roomNumber, "userId": ASFirebaseAuth.myID, "mode": mode.rawValue]
             )
             guard let isSuccess = response["success"] as? Bool else {
-                throw ASNetworkErrors.responseError
+                throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return isSuccess
         } catch {
-            throw ASRepositoryErrors.changeModeError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .changeMode, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -98,11 +98,11 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
                 requestBody: ["roomNumber": roomNumber, "userId": ASFirebaseAuth.myID]
             )
             guard let isSuccess = response["success"] as? Bool else {
-                throw ASNetworkErrors.responseError
+                throw ASNetworkErrors(type: .responseError, reason: "", file: #file, line: #line)
             }
             return isSuccess
         } catch {
-            throw ASRepositoryErrors.changeRecordOrderError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .changeRecordOrder, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -110,7 +110,7 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
         do {
             return try await mainRepository.postResetGame()
         } catch {
-            throw ASRepositoryErrors.resetGameError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .resetGame, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
     
@@ -122,7 +122,7 @@ final class RoomActionRepository: RoomActionRepositoryProtocol {
             let response = try JSONDecoder().decode(T.self, from: data)
             return response
         } catch {
-            throw ASRepositoryErrors.sendRequestError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .sendRequest, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
@@ -24,15 +24,19 @@ final class SubmitsRepository: SubmitsRepositoryProtocol {
     }
     
     func submitAnswer(answer: Music) async throws -> Bool {
-        let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
-                          URLQueryItem(name: "roomNumber", value: mainRepository.number.value)]
-        let endPoint = FirebaseEndpoint(path: .submitAnswer, method: .post)
-            .update(\.queryItems, with: queryItems)
-            .update(\.headers, with: ["Content-Type": "application/json"])
+        do {
+            let queryItems = [URLQueryItem(name: "userId", value: ASFirebaseAuth.myID),
+                              URLQueryItem(name: "roomNumber", value: mainRepository.number.value)]
+            let endPoint = FirebaseEndpoint(path: .submitAnswer, method: .post)
+                .update(\.queryItems, with: queryItems)
+                .update(\.headers, with: ["Content-Type": "application/json"])
 
-        let body = try ASEncoder.encode(answer)
-        let response = try await networkManager.sendRequest(to: endPoint, type: .json, body: body, option: .none)
-        let responseDict = try ASDecoder.decode([String: String].self, from: response)
-        return !responseDict.isEmpty
+            let body = try ASEncoder.encode(answer)
+            let response = try await networkManager.sendRequest(to: endPoint, type: .json, body: body, option: .none)
+            let responseDict = try ASDecoder.decode([String: String].self, from: response)
+            return !responseDict.isEmpty
+        } catch {
+            throw ASRepositoryErrors.submitAnswerError(reason: error.localizedDescription)
+        }
     }
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/SubmitsRepository.swift
@@ -36,7 +36,7 @@ final class SubmitsRepository: SubmitsRepositoryProtocol {
             let responseDict = try ASDecoder.decode([String: String].self, from: response)
             return !responseDict.isEmpty
         } catch {
-            throw ASRepositoryErrors.submitAnswerError(reason: error.localizedDescription)
+            throw ASRepositoryErrors(type: .submitAnswer, reason: error.localizedDescription, file: #file, line: #line)
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -1,69 +1,25 @@
 import Foundation
 
-enum ASErrors: Error, LocalizedError {
-    case analyzeError(reason: String)
-    case startRecordingError(reason: String)
-    case playFullError(reason: String)
-    case playPartialError(reason: String)
-    case leaveRoomError(reason: String)
-    case submitHummingError(reason: String)
-    case fetchAvatarsError(reason: String)
-    case gameStartError(reason: String)
-    case changeModeError(reason: String)
-    case authorizeAppleMusicError(reason: String)
-    case joinRoomError(reason: String)
-    case createRoomError(reason: String)
-    case submitRehummingError(reason: String)
-    case changeRecordOrderError(reason: String)
-    case navigateToLobbyError(reason: String)
-    case submitMusicError(reason: String)
-    case searchMusicOnSelectError(reason: String)
-    case randomMusicError(reason: String)
-    case searchMusicOnSubmitError(reason: String)
-    case submitAnswerError(reason: String)
+struct ASErrors: LocalizedError {
+    let type: ErrorType
+    let reason: String
+    let file: String
+    let line: Int
+
+    enum ErrorType {
+        case analyze, startRecording, playFull, playPartial
+        case leaveRoom
+        case submitHumming
+        case fetchAvatars
+        case gameStart, changeMode
+        case authorizeAppleMusic, joinRoom, createRoom
+        case submitRehumming
+        case changeRecordOrder, navigateToLobby
+        case submitMusic, searchMusicOnSelect, randomMusic
+        case searchMusicOnSubmit, submitAnswer
+    }
 
     var errorDescription: String? {
-        switch self {
-        case .analyzeError(let reason):
-            return "AudioHelper.swift analyze() 에러: \n\(reason)"
-        case .startRecordingError(let reason):
-            return "AudioHelper.swift startRecording() 에러: \n\(reason)"
-        case .playFullError(let reason):
-            return "AudioHelper.swift play(option: .full) 에러: \n\(reason)"
-        case .playPartialError(let reason):
-            return "AudioHelper.swift play(option: .partial) 에러: \n\(reason)"
-        case .leaveRoomError(let reason):
-            return "GameNavigationController.swift leaveRoom() 에러: \n\(reason)"
-        case .submitHummingError(let reason):
-            return "HummingViewModel.swift submitHumming() 에러: \n\(reason)"
-        case .fetchAvatarsError(let reason):
-            return "LoadingViewModel.swift fetchAvatars() 에러: \n\(reason)"
-        case .gameStartError(let reason):
-            return "LobbyViewModel.swift gameStart() 에러: \n\(reason)"
-        case .changeModeError(let reason):
-            return "LobbyViewModel.swift changeMode() 에러: \n\(reason)"
-        case .authorizeAppleMusicError(let reason):
-            return "OnboardingViewModel.swift authorizeAppleMusic() 에러: \n\(reason)"
-        case .joinRoomError(let reason):
-            return "OnboardingViewModel.swift joinRoom() 에러: \n\(reason)"
-        case .createRoomError(let reason):
-            return "OnboardingViewModel.swift createRoom() 에러: \n\(reason)"
-        case .submitRehummingError(let reason):
-            return "RehummingViewModel.swift submitHumming() 에러: \n\(reason)"
-        case .changeRecordOrderError(let reason):
-            return "HummingResultViewModel.swift changeRecordOrder() 에러: \n\(reason)"
-        case .navigateToLobbyError(let reason):
-            return "HummingResultViewModel.swift navigateToLobby() 에러: \n\(reason)"
-        case .submitMusicError(let reason):
-            return "SelectMusicViewModel.swift submitMusic() 에러: \n\(reason)"
-        case .searchMusicOnSelectError(let reason):
-            return "SelectMusicViewModel.swift searchMusic() 에러: \n\(reason)"
-        case .randomMusicError(let reason):
-            return "SelectMusicViewModel.swift randomMusic() 에러: \n\(reason)"
-        case .searchMusicOnSubmitError(let reason):
-            return "SubmitAnswerViewModel.swift searchMusic() 에러: \n\(reason)"
-        case .submitAnswerError(let reason):
-            return "SubmitAnswerViewModel.swift submitAnswer() 에러: \n\(reason)"
-        }
+        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+enum ASErrors: Error, LocalizedError {
+    case analyzeError(reason: String)
+    case startRecordingError(reason: String)
+    case playFullError(reason: String)
+    case playPartialError(reason: String)
+    case leaveRoomError(reason: String)
+    case submitHummingError(reason: String)
+    case fetchAvatarsError(reason: String)
+    case gameStartError(reason: String)
+    case changeModeError(reason: String)
+    case authorizeAppleMusicError(reason: String)
+    case joinRoomError(reason: String)
+    case createRoomError(reason: String)
+    case submitRehummingError(reason: String)
+    case changeRecordOrderError(reason: String)
+    case navigateToLobbyError(reason: String)
+    case submitMusicError(reason: String)
+    case searchMusicOnSelectError(reason: String)
+    case randomMusicError(reason: String)
+    case searchMusicOnSubmitError(reason: String)
+    case submitAnswerError(reason: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .analyzeError(let reason):
+            return "AudioHelper.swift analyze() 에러: \n\(reason)"
+        case .startRecordingError(let reason):
+            return "AudioHelper.swift startRecording() 에러: \n\(reason)"
+        case .playFullError(let reason):
+            return "AudioHelper.swift play(option: .full) 에러: \n\(reason)"
+        case .playPartialError(let reason):
+            return "AudioHelper.swift play(option: .partial) 에러: \n\(reason)"
+        case .leaveRoomError(let reason):
+            return "GameNavigationController.swift leaveRoom() 에러: \n\(reason)"
+        case .submitHummingError(let reason):
+            return "HummingViewModel.swift submitHumming() 에러: \n\(reason)"
+        case .fetchAvatarsError(let reason):
+            return "LoadingViewModel.swift fetchAvatars() 에러: \n\(reason)"
+        case .gameStartError(let reason):
+            return "LobbyViewModel.swift gameStart() 에러: \n\(reason)"
+        case .changeModeError(let reason):
+            return "LobbyViewModel.swift changeMode() 에러: \n\(reason)"
+        case .authorizeAppleMusicError(let reason):
+            return "OnboardingViewModel.swift authorizeAppleMusic() 에러: \n\(reason)"
+        case .joinRoomError(let reason):
+            return "OnboardingViewModel.swift joinRoom() 에러: \n\(reason)"
+        case .createRoomError(let reason):
+            return "OnboardingViewModel.swift createRoom() 에러: \n\(reason)"
+        case .submitRehummingError(let reason):
+            return "RehummingViewModel.swift submitHumming() 에러: \n\(reason)"
+        case .changeRecordOrderError(let reason):
+            return "HummingResultViewModel.swift changeRecordOrder() 에러: \n\(reason)"
+        case .navigateToLobbyError(let reason):
+            return "HummingResultViewModel.swift navigateToLobby() 에러: \n\(reason)"
+        case .submitMusicError(let reason):
+            return "SelectMusicViewModel.swift submitMusic() 에러: \n\(reason)"
+        case .searchMusicOnSelectError(let reason):
+            return "SelectMusicViewModel.swift searchMusic() 에러: \n\(reason)"
+        case .randomMusicError(let reason):
+            return "SelectMusicViewModel.swift randomMusic() 에러: \n\(reason)"
+        case .searchMusicOnSubmitError(let reason):
+            return "SubmitAnswerViewModel.swift searchMusic() 에러: \n\(reason)"
+        case .submitAnswerError(let reason):
+            return "SubmitAnswerViewModel.swift submitAnswer() 에러: \n\(reason)"
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/ASErrors.swift
@@ -20,6 +20,6 @@ struct ASErrors: LocalizedError {
     }
 
     var errorDescription: String? {
-        return "[\(file):\(line)] \(type) 에러: \n\(reason)"
+        return "\n[\(URL(fileURLWithPath: file).lastPathComponent):\(line)] \(type) 에러: \n\(reason)"
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/AudioHelper.swift
@@ -74,7 +74,8 @@ actor AudioHelper {
             LogHandler.handleDebug(columns)
             return columns
         } catch {
-            LogHandler.handleError(.analyzeError(reason: error.localizedDescription))
+            let error = ASErrors(type: .analyze, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
             return []
         }
     }
@@ -116,7 +117,8 @@ extension AudioHelper {
                 do {
                     try await player?.startPlaying(data: file)
                 } catch {
-                    LogHandler.handleError(.playFullError(reason: error.localizedDescription))
+                    let error = ASErrors(type: .playFull, reason: error.localizedDescription, file: #file, line: #line)
+                    LogHandler.handleError(error)
                 }
             case let .partial(time):
                 do {
@@ -124,7 +126,8 @@ extension AudioHelper {
                     try await Task.sleep(nanoseconds: UInt64(time * 1_000_000_000))
                     await stopPlaying()
                 } catch {
-                    LogHandler.handleError(.playPartialError(reason: error.localizedDescription))
+                    let error = ASErrors(type: .playPartial, reason: error.localizedDescription, file: #file, line: #line)
+                    LogHandler.handleError(error)
                 }
             @unknown default: break
         }
@@ -183,7 +186,8 @@ extension AudioHelper {
             let recordedData = await stopRecording()
             sendDataThrough(recorderDataSubject, recordedData ?? Data())
         } catch {
-            LogHandler.handleError(.startRecordingError(reason: error.localizedDescription))
+            let error = ASErrors(type: .startRecording, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/LogHandler.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Utils/LogHandler.swift
@@ -1,0 +1,15 @@
+import ASLogKit
+
+enum LogHandler {
+    static func handleError(_ message: String) {
+        Logger.error(message)
+    }
+
+    static func handleError(_ error: ASErrors) {
+        handleError(error.localizedDescription)
+    }
+
+    static func handleDebug(_ message: Any) {
+        Logger.debug(message)
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -1,6 +1,5 @@
 import ASContainer
 import ASEntity
-import ASLogKit
 import ASRepositoryProtocol
 import Combine
 import UIKit
@@ -287,7 +286,7 @@ final class GameNavigationController: @unchecked Sendable {
             do {
                 _ = try await roomActionRepository.leaveRoom()
             } catch {
-                Logger.error(error.localizedDescription)
+                LogHandler.handleError(.leaveRoomError(reason: error.localizedDescription))
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -286,7 +286,8 @@ final class GameNavigationController: @unchecked Sendable {
             do {
                 _ = try await roomActionRepository.leaveRoom()
             } catch {
-                LogHandler.handleError(.leaveRoomError(reason: error.localizedDescription))
+                let error = ASErrors(type: .leaveRoom, reason: error.localizedDescription, file: #file, line: #line)
+                LogHandler.handleError(error)
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -1,5 +1,4 @@
 import ASEntity
-import ASLogKit
 import ASRepositoryProtocol
 import Combine
 import Foundation
@@ -46,9 +45,9 @@ final class HummingViewModel: @unchecked Sendable {
     private func submitHumming() async {
         do {
             let result = try await recordsRepository.uploadRecording(recordedData ?? Data())
-            if !result { Logger.error("Humming Did not sent") }
+            if !result { LogHandler.handleError("Humming Did not sent") }
         } catch {
-            Logger.error(error.localizedDescription)
+            LogHandler.handleError(.submitHummingError(reason: error.localizedDescription))
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Humming/HummingViewModel.swift
@@ -47,7 +47,8 @@ final class HummingViewModel: @unchecked Sendable {
             let result = try await recordsRepository.uploadRecording(recordedData ?? Data())
             if !result { LogHandler.handleError("Humming Did not sent") }
         } catch {
-            LogHandler.handleError(.submitHummingError(reason: error.localizedDescription))
+            let error = ASErrors(type: .submitHumming, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -21,22 +21,26 @@ final class LoadingViewModel: @unchecked Sendable {
     
     func fetchAvatars() {
         Task {
-            loadingStatus = String(localized: "게임 데이터 불러오는 중")
-            avatars = try await avatarRepository.getAvatarUrls()
-            
-            guard let randomAvatarUrl = avatars.randomElement() else { return }
-            selectedAvatar = randomAvatarUrl
-            loadingStatus = String(localized: "아바타 이미지 다운로드 중")
-            
-            await withTaskGroup(of: Data?.self) { group in
-                avatars.forEach { url in
-                    group.addTask { [weak self] in
-                        return await self?.dataDownloadRepository.downloadData(url: url)
+            do {
+                loadingStatus = String(localized: "게임 데이터 불러오는 중")
+                avatars = try await avatarRepository.getAvatarUrls()
+
+                guard let randomAvatarUrl = avatars.randomElement() else { return }
+                selectedAvatar = randomAvatarUrl
+                loadingStatus = String(localized: "아바타 이미지 다운로드 중")
+
+                await withTaskGroup(of: Data?.self) { group in
+                    avatars.forEach { url in
+                        group.addTask { [weak self] in
+                            return await self?.dataDownloadRepository.downloadData(url: url)
+                        }
                     }
                 }
+
+                avatarData = await dataDownloadRepository.downloadData(url: randomAvatarUrl)
+            } catch {
+                LogHandler.handleError(.fetchAvatarsError(reason: error.localizedDescription))
             }
-            
-            avatarData = await dataDownloadRepository.downloadData(url: randomAvatarUrl)
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewModel.swift
@@ -39,7 +39,8 @@ final class LoadingViewModel: @unchecked Sendable {
 
                 avatarData = await dataDownloadRepository.downloadData(url: randomAvatarUrl)
             } catch {
-                LogHandler.handleError(.fetchAvatarsError(reason: error.localizedDescription))
+                let error = ASErrors(type: .fetchAvatars, reason: error.localizedDescription, file: #file, line: #line)
+                LogHandler.handleError(error)
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -125,11 +125,7 @@ final class LobbyViewController: UIViewController {
     }
 
     private func gameStart() async throws {
-        do {
-            try await viewmodel.gameStart()
-        } catch {
-            throw error
-        }
+        try await viewmodel.gameStart()
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -93,8 +93,9 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
         do {
             _ = try await roomActionRepository.startGame(roomNumber: roomNumber)
         } catch {
-            LogHandler.handleError(.gameStartError(reason: error.localizedDescription))
-            throw ASErrors.gameStartError(reason: error.localizedDescription)
+            let error = ASErrors(type: .gameStart, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error.localizedDescription)
+            throw error
         }
     }
 
@@ -105,7 +106,8 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
                     _ = try await self.roomActionRepository.changeMode(roomNumber: roomNumber, mode: mode)
                 }
             } catch {
-                LogHandler.handleError(.changeModeError(reason: error.localizedDescription))
+                let error = ASErrors(type: .changeMode, reason: error.localizedDescription, file: #file, line: #line)
+                LogHandler.handleError(error)
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewModel.swift
@@ -1,5 +1,4 @@
 import ASEntity
-import ASLogKit
 import ASRepositoryProtocol
 import Combine
 import Foundation
@@ -94,7 +93,8 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
         do {
             _ = try await roomActionRepository.startGame(roomNumber: roomNumber)
         } catch {
-            throw error
+            LogHandler.handleError(.gameStartError(reason: error.localizedDescription))
+            throw ASErrors.gameStartError(reason: error.localizedDescription)
         }
     }
 
@@ -105,7 +105,7 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
                     _ = try await self.roomActionRepository.changeMode(roomNumber: roomNumber, mode: mode)
                 }
             } catch {
-                Logger.error(error.localizedDescription)
+                LogHandler.handleError(.changeModeError(reason: error.localizedDescription))
             }
         }
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -42,7 +42,11 @@ final class OnboardingViewModel: @unchecked Sendable {
     func authorizeAppleMusic() {
         let musicAPI = ASMusicAPI()
         Task {
-            let _ = try await musicAPI.search(for: "뉴진스", 1, 1)
+            do {
+                let _ = try await musicAPI.search(for: "뉴진스", 1, 1)
+            } catch {
+                LogHandler.handleError(.authorizeAppleMusicError(reason: error.localizedDescription))
+            }
         }
     }
 
@@ -55,7 +59,8 @@ final class OnboardingViewModel: @unchecked Sendable {
             return id
         } catch {
             buttonEnabled = true
-            throw error
+            LogHandler.handleError(.joinRoomError(reason: error.localizedDescription))
+            throw ASErrors.joinRoomError(reason: error.localizedDescription)
         }
     }
 
@@ -68,7 +73,8 @@ final class OnboardingViewModel: @unchecked Sendable {
             return try await joinRoom(roomNumber: roomNumber)
         } catch {
             buttonEnabled = true
-            throw error
+            LogHandler.handleError(.createRoomError(reason: error.localizedDescription))
+            throw ASErrors.createRoomError(reason: error.localizedDescription)
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -45,7 +45,8 @@ final class OnboardingViewModel: @unchecked Sendable {
             do {
                 let _ = try await musicAPI.search(for: "뉴진스", 1, 1)
             } catch {
-                LogHandler.handleError(.authorizeAppleMusicError(reason: error.localizedDescription))
+                let error = ASErrors(type: .authorizeAppleMusic, reason: error.localizedDescription, file: #file, line: #line)
+                LogHandler.handleError(error)
             }
         }
     }
@@ -59,8 +60,10 @@ final class OnboardingViewModel: @unchecked Sendable {
             return id
         } catch {
             buttonEnabled = true
-            LogHandler.handleError(.joinRoomError(reason: error.localizedDescription))
-            throw ASErrors.joinRoomError(reason: error.localizedDescription)
+
+            let error = ASErrors(type: .joinRoom, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
 
@@ -73,8 +76,10 @@ final class OnboardingViewModel: @unchecked Sendable {
             return try await joinRoom(roomNumber: roomNumber)
         } catch {
             buttonEnabled = true
-            LogHandler.handleError(.createRoomError(reason: error.localizedDescription))
-            throw ASErrors.createRoomError(reason: error.localizedDescription)
+
+            let error = ASErrors(type: .createRoom, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -31,8 +31,9 @@ final class RehummingViewModel: @unchecked Sendable {
         do {
             let result = try await recordsRepository.uploadRecording(recordedData)
         } catch {
-            LogHandler.handleError(.submitRehummingError(reason: error.localizedDescription))
-            throw ASErrors.submitRehummingError(reason: error.localizedDescription)
+            let error = ASErrors(type: .submitHumming, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Rehumming/RehummingViewModel.swift
@@ -30,13 +30,9 @@ final class RehummingViewModel: @unchecked Sendable {
         guard let recordedData else { return }
         do {
             let result = try await recordsRepository.uploadRecording(recordedData)
-            if result {
-                // 전송됨
-            } else {
-                // 전송 안됨, 오류 alert
-            }
         } catch {
-            throw error
+            LogHandler.handleError(.submitRehummingError(reason: error.localizedDescription))
+            throw ASErrors.submitRehummingError(reason: error.localizedDescription)
         }
     }
 
@@ -48,7 +44,10 @@ final class RehummingViewModel: @unchecked Sendable {
 
     func updateRecordedData(with data: Data) {
         // TODO: - data가 empty일 때(녹음이 제대로 되지 않았을 때 사용자 오류처리 필요
-        guard !data.isEmpty else { return }
+        guard !data.isEmpty else {
+            isRecording = false
+            return
+        }
         recordedData = data
         isRecording = false
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -93,7 +93,8 @@ final class HummingResultViewModel: @unchecked Sendable {
             let succeded = try await roomActionRepository.changeRecordOrder(roomNumber: roomNumber)
             if !succeded { LogHandler.handleError("Changing RecordOrder failed") }
         } catch {
-            LogHandler.handleError(.changeRecordOrderError(reason: error.localizedDescription))
+            let error = ASErrors(type: .changeRecordOrder, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
         }
     }
 
@@ -103,7 +104,8 @@ final class HummingResultViewModel: @unchecked Sendable {
             let succeded = try await roomActionRepository.resetGame()
             if !succeded { LogHandler.handleError("Game Reset failed") }
         } catch {
-            LogHandler.handleError(.navigateToLobbyError(reason: error.localizedDescription))
+            let error = ASErrors(type: .navigateToLobby, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -113,17 +113,23 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             do {
                 _ = try await answersRepository.submitMusic(answer: selectedMusic)
             } catch {
-                throw error
+                LogHandler.handleError(.submitMusicError(reason: error.localizedDescription))
+                throw ASErrors.submitMusicError(reason: error.localizedDescription)
             }
         }
     }
  
     func searchMusic(text: String) async throws {
-        if text.isEmpty { return }
-        await updateIsSearching(with: true)
-        let searchList = try await musicAPI.search(for: text)
-        await updateSearchList(with: searchList)
-        await updateIsSearching(with: false)
+        do {
+            if text.isEmpty { return }
+            await updateIsSearching(with: true)
+            let searchList = try await musicAPI.search(for: text)
+            await updateSearchList(with: searchList)
+            await updateIsSearching(with: false)
+        } catch {
+            LogHandler.handleError(.searchMusicOnSelectError(reason: error.localizedDescription))
+            throw ASErrors.searchMusicOnSelectError(reason: error.localizedDescription)
+        }
     }
     
     @MainActor
@@ -131,7 +137,8 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         do {
             selectedMusic = try await musicAPI.randomSong(from: "pl.u-aZb00o7uPlzMZzr")
         } catch {
-            throw error
+            LogHandler.handleError(.randomMusicError(reason: error.localizedDescription))
+            throw ASErrors.randomMusicError(reason: error.localizedDescription)
         }
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SelectMusic/SelectMusicViewModel.swift
@@ -113,8 +113,9 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             do {
                 _ = try await answersRepository.submitMusic(answer: selectedMusic)
             } catch {
-                LogHandler.handleError(.submitMusicError(reason: error.localizedDescription))
-                throw ASErrors.submitMusicError(reason: error.localizedDescription)
+                let error = ASErrors(type: .submitMusic, reason: error.localizedDescription, file: #file, line: #line)
+                LogHandler.handleError(error)
+                throw error
             }
         }
     }
@@ -127,8 +128,9 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
             await updateSearchList(with: searchList)
             await updateIsSearching(with: false)
         } catch {
-            LogHandler.handleError(.searchMusicOnSelectError(reason: error.localizedDescription))
-            throw ASErrors.searchMusicOnSelectError(reason: error.localizedDescription)
+            let error = ASErrors(type: .searchMusicOnSelect, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
     
@@ -137,8 +139,9 @@ final class SelectMusicViewModel: ObservableObject, @unchecked Sendable {
         do {
             selectedMusic = try await musicAPI.randomSong(from: "pl.u-aZb00o7uPlzMZzr")
         } catch {
-            LogHandler.handleError(.randomMusicError(reason: error.localizedDescription))
-            throw ASErrors.randomMusicError(reason: error.localizedDescription)
+            let error = ASErrors(type: .randomMusic, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
     

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -136,7 +136,8 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
             await updateSearchList(with: searchList)
             await updateIsSearching(with: false)
         } catch {
-            throw error
+            LogHandler.handleError(.searchMusicOnSubmitError(reason: error.localizedDescription))
+            throw ASErrors.searchMusicOnSubmitError(reason: error.localizedDescription)
         }
     }
 
@@ -153,10 +154,10 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
     func submitAnswer() async throws {
         guard let selectedMusic else { return }
         do {
-            let response = try await submitsRepository.submitAnswer(answer: selectedMusic)
-
+            let _ = try await submitsRepository.submitAnswer(answer: selectedMusic)
         } catch {
-            throw error
+            LogHandler.handleError(.submitAnswerError(reason: error.localizedDescription))
+            throw ASErrors.submitAnswerError(reason: error.localizedDescription)
         }
     }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/SubmitAnswer/SubmitAnswerViewModel.swift
@@ -136,8 +136,9 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
             await updateSearchList(with: searchList)
             await updateIsSearching(with: false)
         } catch {
-            LogHandler.handleError(.searchMusicOnSubmitError(reason: error.localizedDescription))
-            throw ASErrors.searchMusicOnSubmitError(reason: error.localizedDescription)
+            let error = ASErrors(type: .searchMusicOnSubmit, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
 
@@ -156,8 +157,9 @@ final class SubmitAnswerViewModel: ObservableObject, @unchecked Sendable {
         do {
             let _ = try await submitsRepository.submitAnswer(answer: selectedMusic)
         } catch {
-            LogHandler.handleError(.submitAnswerError(reason: error.localizedDescription))
-            throw ASErrors.submitAnswerError(reason: error.localizedDescription)
+            let error = ASErrors(type: .submitAnswer, reason: error.localizedDescription, file: #file, line: #line)
+            LogHandler.handleError(error)
+            throw error
         }
     }
 


### PR DESCRIPTION
## 관련 이슈

- #18 

## 완료 및 수정 내역

 - [x] 에러 핸들링 구체화

## 리뷰 노트

### 과정
1차로 Business Model의 에러를 추가 및 구체화 하고,
2차로 Repository Layer의 에러를 추가 및 구체화 하고,
3차로 Presentation Layer의 에러를 추가 및 구체화 했습니다.

어떻게 해야 Error Log를 보고 개발자가 쉽게 상황을 파악할 수 있을까 고민한 결과,
1차에서 throw한 Error가 2차로, 2차에서 throw한 Error가 3차로 가 최종적으로 ViewModel에서 로그로 출력되게 했습니다.

각 부분에서 독립적으로 로그를 찍게할 수도 있지만, 그렇게 하면 로그를 보고 개발자가 다시 어떤 흐름에서 발생했는지, 예를 들어 HummingViewModel -> RoomActionRepository -> Network의 흐름에서 Network에서만 에러 로그가 찍힌다면 해당 에러 로그가 HummingViewModel에서 발생했는지 아니면 Network에 연결하는 다른 ViewModel에서 발생했는지 파악해야하는 과정이 필요하게 됩니다. 

따라서 Presentation Layer 이전의 Error는 따로 로그로 찍지 않고, throw만 하게 한 뒤 Presentation Layer 까지 전달이 됐을 때 흐름을 타고 출력하게 했습니다.

![image](https://github.com/user-attachments/assets/34bc329b-f430-4dff-b5d4-ca14a49fc074)

물론 정의된 Error를 throw하기 때문에, 필요에 따라 각 Layer에서 throw된 Error를 로그에 따로 찍을 수 있습니다.

Presentation Layer에서는 각 ViewModel에서 사용하던 ASLogKit 의존성을 없애고 한 곳에서 통합 및 에러를 관리하고자 LogHandler와 ASErrors를 추가했습니다.

정의한 Errors는 선행 코드의 에러를 포함하고자 localizedDescription을 매개변수로 전달받게 했습니다.

DataDownloadRepository와 AudioHelper를 제외하고 다른 모든 Business Model과 Repository Layer의 Error는 ViewModel 단계에서 로그에 찍힙니다.

제외된 두 코드는 사용하는 하위 코드가 많아 ViewModel까지 분류하기에 무리가 있다 판단하여 각 코드 내에서 로그를 찍도록 했습니다.