### PR TITLE
[Feat] 튜토리얼 로비

### DIFF
--- a/alsongDalsong/ASEntity/ASEntity/TutorialState.swift
+++ b/alsongDalsong/ASEntity/ASEntity/TutorialState.swift
@@ -1,0 +1,3 @@
+public enum TutorialState {
+    case start
+}

--- a/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Mock/PlayersMockRepository.swift
@@ -21,6 +21,10 @@ public final class PlayersMockRepository: PlayersRepositoryProtocol {
             .eraseToAnyPublisher()
     }
     
+    public func getTutorialPlayer() -> ASEntity.Player? {
+        Player.playerStub1
+    }
+    
     public func getPlayersCount() -> AnyPublisher<Int, Never> {
         playersPublisher
             .compactMap { $0 }

--- a/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Protocols/RepositoryProtocols.swift
@@ -16,6 +16,7 @@ public protocol GameStatusRepositoryProtocol {
 
 public protocol PlayersRepositoryProtocol {
     func getPlayers() -> AnyPublisher<[Player], Never>
+    func getTutorialPlayer() -> Player?
     func getHost() -> AnyPublisher<Player, Never>
     func isHost() -> AnyPublisher<Bool, Never>
     func getPlayersCount() -> AnyPublisher<Int, Never>
@@ -61,4 +62,8 @@ public protocol HummingResultRepositoryProtocol {
 
 public protocol DataDownloadRepositoryProtocol {
     func downloadData(url: URL) async -> Data?
+}
+
+public protocol SaveDataRepositoryProtocol  {
+    func savePlayer(tutorialPlayer: Player)
 }

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/PlayersRepository.swift
@@ -6,7 +6,8 @@ import ASRepositoryProtocol
 
 final class PlayersRepository: PlayersRepositoryProtocol {
     private var mainRepository: MainRepositoryProtocol
-    
+    private let defaults = UserDefaults.standard
+
     init(mainRepository: MainRepositoryProtocol) {
         self.mainRepository = mainRepository
     }
@@ -16,6 +17,16 @@ final class PlayersRepository: PlayersRepositoryProtocol {
             .receive(on: DispatchQueue.main)
             .compactMap { $0 }
             .eraseToAnyPublisher()
+    }
+    
+    func getTutorialPlayer() -> Player? {
+        if let savedData = defaults.object(forKey: "tutorialPlayer") as? Data {
+            let decoder = JSONDecoder()
+            if let savedPlayer = try? decoder.decode(Player.self, from: savedData) {
+                return savedPlayer
+            }
+        }
+        return nil
     }
     
     func getPlayersCount() -> AnyPublisher<Int, Never> {

--- a/alsongDalsong/ASRepository/ASRepository/Repositories/SaveDataRepository.swift
+++ b/alsongDalsong/ASRepository/ASRepository/Repositories/SaveDataRepository.swift
@@ -1,0 +1,13 @@
+import ASRepositoryProtocol
+import ASEntity
+
+final class SaveDataRepository: SaveDataRepositoryProtocol {
+    private let defaults = UserDefaults.standard
+    private let encoder = JSONEncoder()
+
+    func savePlayer(tutorialPlayer: Player) {
+        if let encoded = try? encoder.encode(tutorialPlayer){
+            defaults.setValue(encoded, forKey: "tutorialPlayer")
+        }
+    }
+}

--- a/alsongDalsong/ASRepository/ASRepository/RepsotioryAssembly.swift
+++ b/alsongDalsong/ASRepository/ASRepository/RepsotioryAssembly.swift
@@ -97,5 +97,9 @@ public struct RepsotioryAssembly: Assembly {
                 networkManager: networkManager
             )
         }
+        
+        container.register(SaveDataRepositoryProtocol.self) { r in
+            SaveDataRepository()
+        }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Localizable.xcstrings
@@ -828,6 +828,26 @@
         }
       }
     },
+    "튜토리얼" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tutorial"
+          }
+        }
+      }
+    },
+    "튜토리얼 시작!" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start Tutorial"
+          }
+        }
+      }
+    },
     "틀틀보" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Components/UIKitComponents/Alert/ASAlertController.swift
@@ -178,6 +178,7 @@ enum ASAlertText {
     enum ProgressText: CustomStringConvertible {
         case joinRoom
         case startGame
+        case startTutorial
         case submitMusic
         case submitHumming
         case nextResult
@@ -187,6 +188,7 @@ enum ASAlertText {
             switch self {
                 case .joinRoom: "방 정보를 가져오는 중..."
                 case .startGame: "게임을 시작하는 중..."
+                case .startTutorial: "튜토리얼 시작하는 중..."
                 case .submitMusic: "노래를 전송하는 중..."
                 case .submitHumming: "허밍을 전송하는 중..."
                 case .nextResult: "다음 결과를 가져오는 중..."

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/AIGameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/AIGameNavigationController.swift
@@ -1,0 +1,66 @@
+import ASContainer
+import ASEntity
+import ASRepositoryProtocol
+import UIKit
+
+@MainActor
+final class AIGameNavigationController: GameNavigationController, @unchecked Sendable {
+    private var aiImageURL: [URL?]
+    private var tutorialStep: TutorialState? {
+        didSet {
+            updateViewControllers()
+        }
+    }
+
+    init(navigationController: UINavigationController, aiImageURL: [URL?]) {
+        self.aiImageURL = aiImageURL
+        super.init(with: navigationController)
+    }
+    
+    override func setConfiguration() {
+        tutorialStep = .start
+    }
+    
+    override func navigateToLobby() {
+        super.navigateToLobby()
+        
+        let dataDownloadRepository: DataDownloadRepositoryProtocol = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+        let playersRepository: PlayersRepositoryProtocol = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        
+        let vm: LobbyViewModel = AILobbyViewModel(
+            dataDownloadRepository: dataDownloadRepository,
+            playersRepository: playersRepository,
+            aiImageURL: aiImageURL.compactMap { $0 }
+        )
+        let vc = LobbyViewController(lobbyViewModel: vm)
+        setupNavigationBar(for: vc)
+        navigationController.pushViewController(vc, animated: true)
+    }
+    
+    private func updateViewControllers() {
+        switch tutorialStep {
+            case .start:
+                navigateToLobby()
+            default:
+                break
+        }
+    }
+    
+    override func setupNavigationBar(for viewController: UIViewController) {
+        super.setupNavigationBar(for: viewController)
+        
+        viewController.navigationItem.hidesBackButton = true
+        viewController.title = setTitle()
+
+    }
+}
+
+private extension AIGameNavigationController {
+    func setTitle() -> String {
+        switch tutorialStep {
+        case .start:
+            return String(localized: "튜토리얼")
+        default: return ""
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GameNavigationController.swift
@@ -1,47 +1,24 @@
-import ASContainer
-import ASEntity
-import ASRepositoryProtocol
-import Combine
 import UIKit
 
 @MainActor
-final class GameNavigationController: @unchecked Sendable {
-    private let navigationController: UINavigationController
-    private let gameStateRepository: GameStateRepositoryProtocol
-    private let roomActionRepository: RoomActionRepositoryProtocol
-    private var subscriptions: Set<AnyCancellable> = []
+class GameNavigationController: @unchecked Sendable {
+    let navigationController: UINavigationController
+    
+    init(with navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    func setConfiguration() {}
+    func setFont() -> FontName { .dohyeon }
+    func navigateToLobby() {
+        if navigationController.topViewController is LobbyViewController { return }
 
-    private var gameInfo: GameState? {
-        didSet {
-            guard let gameInfo else { return }
-            updateViewControllers(state: gameInfo)
+        if let vc = navigationController.viewControllers.first(where: { $0 is LobbyViewController }) {
+            navigationController.popToViewController(vc, animated: true)
+            return
         }
     }
-
-    private let roomNumber: String
-
-    init(navigationController: UINavigationController,
-         gameStateRepository: GameStateRepositoryProtocol,
-         roomActionRepository: RoomActionRepositoryProtocol,
-         roomNumber: String)
-    {
-        self.navigationController = navigationController
-        self.gameStateRepository = gameStateRepository
-        self.roomActionRepository = roomActionRepository
-        self.roomNumber = roomNumber
-    }
-
-    func setConfiguration() {
-        gameStateRepository.getGameState()
-            .receive(on: DispatchQueue.main)
-            .compactMap { $0 }
-            .sink { [weak self] gameState in
-                self?.gameInfo = gameState
-            }
-            .store(in: &subscriptions)
-    }
-
-    private func setupNavigationBar(for viewController: UIViewController) {
+    func setupNavigationBar(for viewController: UIViewController) {
         navigationController.navigationBar.isHidden = false
         navigationController.navigationBar.tintColor = .asBlack
         let defaultFontSize = UIFont.preferredFont(forTextStyle: .headline).pointSize as CGFloat?
@@ -52,243 +29,5 @@ final class GameNavigationController: @unchecked Sendable {
             fontStyle = .font(setFont(), ofSize: 18)
         }
         navigationController.navigationBar.titleTextAttributes = [.font: fontStyle]
-        let backButtonImage = setImage()
-
-        let backButtonAction = UIAction { [weak self] _ in
-            let alert = DefaultAlertController(
-                titleText: .leaveRoom,
-                primaryButtonText: .leave,
-                secondaryButtonText: .cancel
-            ) { [weak self] _ in
-                self?.leaveRoom()
-                self?.navigationController.popToRootViewController(animated: true)
-                self?.navigationController.navigationBar.isHidden = true
-            }
-            self?.navigationController.presentAlert(alert)
-        }
-
-        let backButton = UIBarButtonItem(image: backButtonImage, primaryAction: backButtonAction)
-
-        viewController.navigationItem.leftBarButtonItem = backButton
-        viewController.title = setTitle()
-    }
-
-    private func setTitle() -> String {
-        guard let gameInfo else { return "" }
-        let viewType = gameInfo.resolveViewType()
-        switch viewType {
-            case .submitMusic:
-                return String(localized: "노래 선택")
-            case .humming:
-                return String(localized: "허밍")
-            case .rehumming:
-                guard let recordOrder = gameInfo.recordOrder else { return "" }
-                let rounds = gameInfo.players.count - 2
-                return String(localized: "리허밍") + "\(recordOrder)/\(rounds)"
-            case .submitAnswer:
-                return String(localized: "정답 맞추기")
-            case .result:
-                guard let recordOrder = gameInfo.recordOrder else { return "" }
-                let currentRound = Int(recordOrder) - (gameInfo.players.count - 2)
-                return String(localized: "결과 확인") + " \(currentRound)/\(gameInfo.players.count)"
-            case .lobby:
-                return "#\(roomNumber)"
-            default:
-                return ""
-        }
-    }
-    
-    private func setFont() -> FontName {
-        let viewType = gameInfo?.resolveViewType()
-        if case .lobby = viewType {
-            return .neoDunggeunmoPro
-        } else {
-            return .dohyeon
-        }
-    }
-
-    private func setImage() -> UIImage? {
-        guard let gameInfo else { return UIImage() }
-        let viewType = gameInfo.resolveViewType()
-        switch viewType {
-            case .lobby: return UIImage(systemName: "rectangle.portrait.and.arrow.forward")?
-            .rotate(radians: .pi)
-            default: return UIImage(systemName: "house")
-        }
-    }
-
-    private func updateViewControllers(state: GameState) {
-        let viewType = state.resolveViewType()
-        switch viewType {
-            case .submitMusic:
-                navigateToSelectMusic()
-            case .humming:
-                navigateToHumming()
-            case .rehumming:
-                navigateToRehumming()
-            case .submitAnswer:
-                navigateToSubmitAnswer()
-            case .result:
-                navigateToResult()
-            case .lobby:
-                navigateToLobby()
-            default:
-                break
-        }
-    }
-
-    private func navigateToLobby() {
-        if navigationController.topViewController is LobbyViewController {
-            return
-        }
-
-        if let vc = navigationController.viewControllers.first(where: { $0 is LobbyViewController }) {
-            navigationController.popToViewController(vc, animated: true)
-            return
-        }
-
-        let roomInfoRepository: RoomInfoRepositoryProtocol = DIContainer.shared.resolve(RoomInfoRepositoryProtocol.self)
-        let playersRepository: PlayersRepositoryProtocol = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-        let roomActionRepository: RoomActionRepositoryProtocol = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
-        let dataDownloadRepository: DataDownloadRepositoryProtocol = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
-
-        let vm = LobbyViewModel(
-            playersRepository: playersRepository,
-            roomInfoRepository: roomInfoRepository,
-            roomActionRepository: roomActionRepository,
-            dataDownloadRepository: dataDownloadRepository
-        )
-        let vc = LobbyViewController(lobbyViewModel: vm)
-        setupNavigationBar(for: vc)
-        navigationController.pushViewController(vc, animated: true)
-    }
-
-    private func navigateToSelectMusic() {
-        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-        let answersRepository = DIContainer.shared.resolve(AnswersRepositoryProtocol.self)
-        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
-        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
-
-        let vm = SelectMusicViewModel(
-            playersRepository: playersRepository,
-            answerRepository: answersRepository,
-            gameStatusRepository: gameStatusRepository,
-            dataDownloadRepository: dataDownloadRepository
-        )
-        let vc = SelectMusicViewController(selectMusicViewModel: vm)
-
-        let guideVC = GuideViewController(type: .submitMusic) { [weak self] in
-            guard let self else { return }
-            navigationController.pushViewController(vc, animated: true)
-            setupNavigationBar(for: vc)
-        }
-        navigationController.pushViewController(guideVC, animated: true)
-    }
-
-    private func navigateToHumming() {
-        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
-        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-        let answersRepository = DIContainer.shared.resolve(AnswersRepositoryProtocol.self)
-        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-
-        let vm = HummingViewModel(
-            gameStatusRepository: gameStatusRepository,
-            playersRepository: playersRepository,
-            answersRepository: answersRepository,
-            recordsRepository: recordsRepository
-        )
-        let vc = HummingViewController(viewModel: vm)
-
-        let guideVC = GuideViewController(type: .humming) { [weak self] in
-            guard let self else { return }
-            navigationController.pushViewController(vc, animated: true)
-            setupNavigationBar(for: vc)
-        }
-        navigationController.pushViewController(guideVC, animated: true)
-    }
-
-    private func navigateToRehumming() {
-        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
-        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-
-        let vm = RehummingViewModel(
-            gameStatusRepository: gameStatusRepository,
-            playersRepository: playersRepository,
-            recordsRepository: recordsRepository
-        )
-        let vc = RehummingViewController(viewModel: vm)
-
-        let guideVC = GuideViewController(type: .rehumming) { [weak self] in
-            guard let self else { return }
-            navigationController.pushViewController(vc, animated: true)
-            setupNavigationBar(for: vc)
-        }
-        navigationController.pushViewController(guideVC, animated: true)
-    }
-
-    private func navigateToSubmitAnswer() {
-        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
-        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
-        let submitsRepository = DIContainer.shared.resolve(SubmitsRepositoryProtocol.self)
-        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
-        
-        let vm = SubmitAnswerViewModel(
-            gameStatusRepository: gameStatusRepository,
-            playersRepository: playersRepository,
-            recordsRepository: recordsRepository,
-            submitsRepository: submitsRepository,
-            dataDownloadRepository: dataDownloadRepository
-        )
-        let vc = SubmitAnswerViewController(viewModel: vm)
-
-        let guideVC = GuideViewController(type: .submitAnswer) { [weak self] in
-            guard let self else { return }
-            navigationController.pushViewController(vc, animated: true)
-            setupNavigationBar(for: vc)
-        }
-        navigationController.pushViewController(guideVC, animated: true)
-    }
-
-    private func navigateToResult() {
-        if navigationController.topViewController is HummingResultViewController {
-            navigationController.topViewController?.title = setTitle()
-            return
-        }
-        let hummingResultRepository = DIContainer.shared.resolve(HummingResultRepositoryProtocol.self)
-        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
-        let playerRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
-        let roomActionRepository = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
-        let roomInfoRepository = DIContainer.shared.resolve(RoomInfoRepositoryProtocol.self)
-        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
-
-        let vm = HummingResultViewModel(
-            hummingResultRepository: hummingResultRepository,
-            gameStatusRepository: gameStatusRepository,
-            playerRepository: playerRepository,
-            roomActionRepository: roomActionRepository,
-            roomInfoRepository: roomInfoRepository,
-            dataDownloadRepository: dataDownloadRepository
-        )
-        let vc = HummingResultViewController(viewModel: vm)
-
-        let guideVC = GuideViewController(type: .result) { [weak self] in
-            guard let self else { return }
-            navigationController.pushViewController(vc, animated: true)
-            setupNavigationBar(for: vc)
-        }
-        navigationController.pushViewController(guideVC, animated: true)
-    }
-
-    private func leaveRoom() {
-        Task {
-            do {
-                _ = try await roomActionRepository.leaveRoom()
-            } catch {
-                let error = ASErrors(type: .leaveRoom, reason: error.localizedDescription, file: #file, line: #line)
-                LogHandler.handleError(error)
-            }
-        }
     }
 }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GeneralGameNavigationController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Game/GeneralGameNavigationController.swift
@@ -1,0 +1,277 @@
+import ASContainer
+import ASEntity
+import ASRepositoryProtocol
+import Combine
+import UIKit
+
+@MainActor
+final class GeneralGameNavigationController: GameNavigationController, @unchecked Sendable {
+    private let gameStateRepository: GameStateRepositoryProtocol
+    private let roomActionRepository: RoomActionRepositoryProtocol
+    private var subscriptions: Set<AnyCancellable> = []
+    private let roomNumber: String
+
+    private var gameInfo: GameState? {
+        didSet {
+            guard let gameInfo else { return }
+            updateViewControllers(state: gameInfo)
+        }
+    }
+
+    init(navigationController: UINavigationController,
+         gameStateRepository: GameStateRepositoryProtocol,
+         roomActionRepository: RoomActionRepositoryProtocol,
+         roomNumber: String)
+    {
+        self.gameStateRepository = gameStateRepository
+        self.roomActionRepository = roomActionRepository
+        self.roomNumber = roomNumber
+        super.init(with: navigationController)
+    }
+
+    override func setConfiguration() {
+        gameStateRepository.getGameState()
+            .receive(on: DispatchQueue.main)
+            .compactMap { $0 }
+            .sink { [weak self] gameState in
+                self?.gameInfo = gameState
+            }
+            .store(in: &subscriptions)
+    }
+
+    override func setupNavigationBar(for viewController: UIViewController) {
+        super.setupNavigationBar(for: viewController)
+        
+        let backButtonImage = setImage()
+        let backButtonAction = UIAction { [weak self] _ in
+            let alert = DefaultAlertController(
+                titleText: .leaveRoom,
+                primaryButtonText: .leave,
+                secondaryButtonText: .cancel
+            ) { [weak self] _ in
+                self?.leaveRoom()
+                self?.navigationController.popToRootViewController(animated: true)
+                self?.navigationController.navigationBar.isHidden = true
+            }
+            self?.navigationController.presentAlert(alert)
+        }
+
+        let backButton = UIBarButtonItem(image: backButtonImage, primaryAction: backButtonAction)
+        viewController.navigationItem.leftBarButtonItem = backButton
+        viewController.title = setTitle()
+    }
+
+    private func setTitle() -> String {
+        guard let gameInfo else { return "" }
+        let viewType = gameInfo.resolveViewType()
+        switch viewType {
+            case .submitMusic:
+                return String(localized: "노래 선택")
+            case .humming:
+                return String(localized: "허밍")
+            case .rehumming:
+                guard let recordOrder = gameInfo.recordOrder else { return "" }
+                let rounds = gameInfo.players.count - 2
+                return String(localized: "리허밍") + "\(recordOrder)/\(rounds)"
+            case .submitAnswer:
+                return String(localized: "정답 맞추기")
+            case .result:
+                guard let recordOrder = gameInfo.recordOrder else { return "" }
+                let currentRound = Int(recordOrder) - (gameInfo.players.count - 2)
+                return String(localized: "결과 확인") + " \(currentRound)/\(gameInfo.players.count)"
+            case .lobby:
+                return "#\(roomNumber)"
+            default:
+                return ""
+        }
+    }
+    
+    override func setFont() -> FontName {
+        let viewType = gameInfo?.resolveViewType()
+        if case .lobby = viewType {
+            return .neoDunggeunmoPro
+        } else {
+            return .dohyeon
+        }
+    }
+
+    override func navigateToLobby() {
+        super.navigateToLobby()
+        
+        let roomInfoRepository: RoomInfoRepositoryProtocol = DIContainer.shared.resolve(RoomInfoRepositoryProtocol.self)
+        let playersRepository: PlayersRepositoryProtocol = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let roomActionRepository: RoomActionRepositoryProtocol = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
+        let dataDownloadRepository: DataDownloadRepositoryProtocol = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+
+        let vm = GeneralLobbyViewModel(
+            playersRepository: playersRepository,
+            roomInfoRepository: roomInfoRepository,
+            roomActionRepository: roomActionRepository,
+            dataDownloadRepository: dataDownloadRepository
+        )
+        let vc = LobbyViewController(lobbyViewModel: vm)
+        setupNavigationBar(for: vc)
+        navigationController.pushViewController(vc, animated: true)
+    }
+}
+
+private extension GeneralGameNavigationController {
+    private func setImage() -> UIImage? {
+        guard let gameInfo else { return UIImage() }
+        let viewType = gameInfo.resolveViewType()
+        switch viewType {
+            case .lobby: return UIImage(systemName: "rectangle.portrait.and.arrow.forward")?
+            .rotate(radians: .pi)
+            default: return UIImage(systemName: "house")
+        }
+    }
+    
+    private func updateViewControllers(state: GameState) {
+        let viewType = state.resolveViewType()
+        switch viewType {
+            case .submitMusic:
+                navigateToSelectMusic()
+            case .humming:
+                navigateToHumming()
+            case .rehumming:
+                navigateToRehumming()
+            case .submitAnswer:
+                navigateToSubmitAnswer()
+            case .result:
+                navigateToResult()
+            case .lobby:
+                navigateToLobby()
+            default:
+                break
+        }
+    }
+    
+    func navigateToSelectMusic() {
+        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let answersRepository = DIContainer.shared.resolve(AnswersRepositoryProtocol.self)
+        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
+        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+
+        let vm = SelectMusicViewModel(
+            playersRepository: playersRepository,
+            answerRepository: answersRepository,
+            gameStatusRepository: gameStatusRepository,
+            dataDownloadRepository: dataDownloadRepository
+        )
+        let vc = SelectMusicViewController(selectMusicViewModel: vm)
+
+        let guideVC = GuideViewController(type: .submitMusic) { [weak self] in
+            guard let self else { return }
+            navigationController.pushViewController(vc, animated: true)
+            setupNavigationBar(for: vc)
+        }
+        navigationController.pushViewController(guideVC, animated: true)
+    }
+    
+    func navigateToHumming() {
+        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
+        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let answersRepository = DIContainer.shared.resolve(AnswersRepositoryProtocol.self)
+        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
+
+        let vm = HummingViewModel(
+            gameStatusRepository: gameStatusRepository,
+            playersRepository: playersRepository,
+            answersRepository: answersRepository,
+            recordsRepository: recordsRepository
+        )
+        let vc = HummingViewController(viewModel: vm)
+
+        let guideVC = GuideViewController(type: .humming) { [weak self] in
+            guard let self else { return }
+            navigationController.pushViewController(vc, animated: true)
+            setupNavigationBar(for: vc)
+        }
+        navigationController.pushViewController(guideVC, animated: true)
+    }
+    
+    func navigateToRehumming() {
+        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
+        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
+
+        let vm = RehummingViewModel(
+            gameStatusRepository: gameStatusRepository,
+            playersRepository: playersRepository,
+            recordsRepository: recordsRepository
+        )
+        let vc = RehummingViewController(viewModel: vm)
+
+        let guideVC = GuideViewController(type: .rehumming) { [weak self] in
+            guard let self else { return }
+            navigationController.pushViewController(vc, animated: true)
+            setupNavigationBar(for: vc)
+        }
+        navigationController.pushViewController(guideVC, animated: true)
+    }
+    
+    func navigateToSubmitAnswer() {
+        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
+        let playersRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let recordsRepository = DIContainer.shared.resolve(RecordsRepositoryProtocol.self)
+        let submitsRepository = DIContainer.shared.resolve(SubmitsRepositoryProtocol.self)
+        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+        
+        let vm = SubmitAnswerViewModel(
+            gameStatusRepository: gameStatusRepository,
+            playersRepository: playersRepository,
+            recordsRepository: recordsRepository,
+            submitsRepository: submitsRepository,
+            dataDownloadRepository: dataDownloadRepository
+        )
+        let vc = SubmitAnswerViewController(viewModel: vm)
+
+        let guideVC = GuideViewController(type: .submitAnswer) { [weak self] in
+            guard let self else { return }
+            navigationController.pushViewController(vc, animated: true)
+            setupNavigationBar(for: vc)
+        }
+        navigationController.pushViewController(guideVC, animated: true)
+    }
+    
+    func navigateToResult() {
+        if navigationController.topViewController is HummingResultViewController {
+            navigationController.topViewController?.title = setTitle()
+            return
+        }
+        let hummingResultRepository = DIContainer.shared.resolve(HummingResultRepositoryProtocol.self)
+        let gameStatusRepository = DIContainer.shared.resolve(GameStatusRepositoryProtocol.self)
+        let playerRepository = DIContainer.shared.resolve(PlayersRepositoryProtocol.self)
+        let roomActionRepository = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
+        let roomInfoRepository = DIContainer.shared.resolve(RoomInfoRepositoryProtocol.self)
+        let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+
+        let vm = HummingResultViewModel(
+            hummingResultRepository: hummingResultRepository,
+            gameStatusRepository: gameStatusRepository,
+            playerRepository: playerRepository,
+            roomActionRepository: roomActionRepository,
+            roomInfoRepository: roomInfoRepository,
+            dataDownloadRepository: dataDownloadRepository
+        )
+        let vc = HummingResultViewController(viewModel: vm)
+
+        let guideVC = GuideViewController(type: .result) { [weak self] in
+            guard let self else { return }
+            navigationController.pushViewController(vc, animated: true)
+            setupNavigationBar(for: vc)
+        }
+        navigationController.pushViewController(guideVC, animated: true)
+    }
+    
+    func leaveRoom() {
+        Task {
+            do {
+                _ = try await roomActionRepository.leaveRoom()
+            } catch {
+                let error = ASErrors(type: .leaveRoom, reason: error.localizedDescription, file: #file, line: #line)
+                LogHandler.handleError(error)
+            }
+        }
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Loading/LoadingViewController.swift
@@ -79,10 +79,12 @@ final class LoadingViewController: UIViewController {
     private func navigateOnboarding(avatars: [URL], selectedAvatar: URL, avatarData: Data) {
         let roomActionRepository = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
         let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
+        let saveDataRepository = DIContainer.shared.resolve(SaveDataRepositoryProtocol.self)
         
         let onboardingVM = OnboardingViewModel(
             roomActionRepository: roomActionRepository,
             dataDownloadRepository: dataDownloadRepository,
+            saveDataRepository: saveDataRepository,
             avatars: avatars,
             selectedAvatar: selectedAvatar,
             avatarData: avatarData

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyPreview.swift
@@ -11,7 +11,7 @@ struct LobbyPreview: PreviewProvider {
         let roomActionRepository = RoomActionMockRepository()
         let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
 
-        let lobbyViewModel = LobbyViewModel(
+        let lobbyViewModel = GeneralLobbyViewModel(
             playersRepository: playerRepository,
             roomInfoRepository: roomInfoRepository,
             roomActionRepository: roomActionRepository,

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -4,6 +4,8 @@ import SwiftUI
 final class LobbyViewController: UIViewController {
     private let inviteButton = ASButton()
     private let startButton = ASButton()
+    private let nextButton = ASButton()
+    private lazy var buttonStack = UIStackView(arrangedSubviews: [inviteButton, startButton, nextButton])
     private var lobbyView = UIViewController()
     private let viewmodel: LobbyViewModel
     private var cancellables: Set<AnyCancellable> = []
@@ -72,12 +74,26 @@ final class LobbyViewController: UIViewController {
             text: String(localized: "시작하기!"),
             backgroundColor: .asMint
         )
+        
+        nextButton.setConfiguration(
+            systemImageName: "play.fill",
+            text: String(localized: "튜토리얼 시작!"),
+            backgroundColor: .asMint
+        )
 
         lobbyView = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
 
         view.addSubview(lobbyView.view)
-        view.addSubview(startButton)
-        view.addSubview(inviteButton)
+        view.addSubview(buttonStack)
+        buttonStack.axis = .vertical
+        buttonStack.spacing = 24
+        
+        if viewmodel as? AILobbyViewModel != nil {
+            inviteButton.isHidden = true
+            startButton.isHidden = true
+        } else {
+            nextButton.isHidden = true
+        }
     }
 
     private func setAction() {
@@ -95,32 +111,39 @@ final class LobbyViewController: UIViewController {
                 guard let playerCount = self?.viewmodel.players.count else { return }
                 playerCount < 3 ?
                     self?.showNeedMorePlayers() :
-                    self?.showStartGameLoading()
+                self?.showStartGameLoading(with: .startGame)
             },
             for: .touchUpInside
         )
+        
+        nextButton.addAction(
+            UIAction { _ in
+                
+            }
+            , for: .touchUpInside)
     }
 
     private func setupLayout() {
+        lobbyView.view.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        
         inviteButton.translatesAutoresizingMaskIntoConstraints = false
         startButton.translatesAutoresizingMaskIntoConstraints = false
-        lobbyView.view.translatesAutoresizingMaskIntoConstraints = false
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
             lobbyView.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            lobbyView.view.bottomAnchor.constraint(equalTo: inviteButton.topAnchor, constant: -20),
+            lobbyView.view.bottomAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -20),
             lobbyView.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             lobbyView.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-
-            inviteButton.bottomAnchor.constraint(equalTo: startButton.topAnchor, constant: -25),
-            inviteButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-            inviteButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            
+            buttonStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            buttonStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+            buttonStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            
             inviteButton.heightAnchor.constraint(equalToConstant: 64),
-
-            startButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-            startButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
-            startButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             startButton.heightAnchor.constraint(equalToConstant: 64),
+            nextButton.heightAnchor.constraint(equalToConstant: 64)
         ])
     }
 
@@ -132,9 +155,9 @@ final class LobbyViewController: UIViewController {
 // MARK: - Alert
 
 extension LobbyViewController {
-    func showStartGameLoading() {
+    func showStartGameLoading(with progressText: ASAlertText.ProgressText) {
         let alert = LoadingAlertController(
-            progressText: .startGame,
+            progressText: progressText,
             loadAction: { [weak self] in
                 try await self?.gameStart()
             },
@@ -151,7 +174,7 @@ extension LobbyViewController {
             primaryButtonText: .keep,
             secondaryButtonText: .cancel
         ) { [weak self] _ in
-            self?.showStartGameLoading()
+            self?.showStartGameLoading(with: .startGame)
         }
         presentAlert(alert)
     }

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/ViewModel/AILobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/ViewModel/AILobbyViewModel.swift
@@ -1,0 +1,21 @@
+import ASEntity
+import ASRepositoryProtocol
+
+final class AILobbyViewModel: LobbyViewModel, @unchecked Sendable {
+    private var playersRepository: PlayersRepositoryProtocol
+    private var aiPlayer: [Player]
+    
+    init(dataDownloadRepository: DataDownloadRepositoryProtocol,
+         playersRepository: PlayersRepositoryProtocol,
+         aiImageURL: [URL]) {
+        self.playersRepository = playersRepository
+
+        aiPlayer = [Player(id: "0", avatarUrl: aiImageURL.first, nickname: "Helper1"),
+                    Player(id: "1", avatarUrl: aiImageURL.last, nickname: "Helper2")]
+        
+        super.init(
+            players: aiPlayer + (playersRepository.getTutorialPlayer().map { [$0] } ?? []),
+            dataDownloadRepository: dataDownloadRepository
+        )
+    }
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/ViewModel/GeneralLobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/ViewModel/GeneralLobbyViewModel.swift
@@ -1,28 +1,10 @@
-import ASEntity
 import ASRepositoryProtocol
 import Combine
-import Foundation
 
-final class LobbyViewModel: ObservableObject, @unchecked Sendable {
+final class GeneralLobbyViewModel: LobbyViewModel, @unchecked Sendable {
     private var playersRepository: PlayersRepositoryProtocol
     private var roomInfoRepository: RoomInfoRepositoryProtocol
     private var roomActionRepository: RoomActionRepositoryProtocol
-    private var dataDownloadRepository: DataDownloadRepositoryProtocol
-
-    let playerMaxCount = 4
-    private(set) var roomNumber: String = ""
-    @Published var players: [Player] = []
-    @Published var host: Player?
-    @Published var isHost: Bool = false
-    @Published var canBeginGame: Bool = false
-    @Published var mode: Mode = .humming {
-        didSet {
-            if mode != oldValue {
-                changeMode()
-            }
-        }
-    }
-
     private var cancellables: Set<AnyCancellable> = []
 
     init(playersRepository: PlayersRepositoryProtocol,
@@ -33,16 +15,11 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
         self.playersRepository = playersRepository
         self.roomActionRepository = roomActionRepository
         self.roomInfoRepository = roomInfoRepository
-        self.dataDownloadRepository = dataDownloadRepository
+        super.init(dataDownloadRepository: dataDownloadRepository)
         fetchData()
     }
 
-    func getAvatarData(url: URL?) async -> Data? {
-        guard let url else { return nil }
-        return await dataDownloadRepository.downloadData(url: url)
-    }
-
-    func fetchData() {
+    override func fetchData() {
         playersRepository.getPlayers()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] players in
@@ -89,7 +66,7 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
             .store(in: &cancellables)
     }
 
-    func gameStart() async throws {
+    override func gameStart() async throws {
         do {
             _ = try await roomActionRepository.startGame(roomNumber: roomNumber)
         } catch {
@@ -99,7 +76,7 @@ final class LobbyViewModel: ObservableObject, @unchecked Sendable {
         }
     }
 
-    func changeMode() {
+    override func changeMode() {
         Task {
             do {
                 if isHost {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/ViewModel/LobbyViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/ViewModel/LobbyViewModel.swift
@@ -1,0 +1,35 @@
+import ASEntity
+import ASRepositoryProtocol
+
+class LobbyViewModel: ObservableObject, @unchecked Sendable {
+    @Published var players: [Player]
+    @Published var isHost: Bool = false
+    @Published var canBeginGame: Bool = false
+    @Published var host: Player?
+    @Published var mode: Mode = .humming {
+        didSet {
+            if mode != oldValue {
+                changeMode()
+            }
+        }
+    }
+    
+    private var dataDownloadRepository: DataDownloadRepositoryProtocol
+    let playerMaxCount: Int
+    var roomNumber: String = ""
+
+    init(playerMaxCount: Int = 4, players: [Player] = [], dataDownloadRepository: DataDownloadRepositoryProtocol) {
+        self.playerMaxCount = playerMaxCount
+        self.players = players
+        self.dataDownloadRepository = dataDownloadRepository
+    }
+    
+    func fetchData() {}
+    func gameStart() async throws {}
+    func getPlayerCount() -> Int { players.count }
+    func getAvatarData(url: URL?) async -> Data? {
+        guard let url else { return nil }
+        return await dataDownloadRepository.downloadData(url: url)
+    }
+    func changeMode() {}
+}

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingPreview.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingPreview.swift
@@ -8,10 +8,12 @@ struct OnboardingPreview: PreviewProvider {
     static var previews: some View {
         let roomActionRepository = RoomActionMockRepository()
         let dataDownloadRepository = DIContainer.shared.resolve(DataDownloadRepositoryProtocol.self)
-
+        let saveDataRepository = DIContainer.shared.resolve(SaveDataRepositoryProtocol.self)
+        
         let onboardingViewModel = OnboardingViewModel(
             roomActionRepository: roomActionRepository,
             dataDownloadRepository: dataDownloadRepository,
+            saveDataRepository: saveDataRepository,
             avatars: [],
             selectedAvatar: nil,
             avatarData: nil

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -1,4 +1,5 @@
 import ASContainer
+import ASEntity
 import ASRepositoryProtocol
 import Combine
 import UIKit
@@ -99,7 +100,8 @@ final class OnboardingViewController: UIViewController {
     private func setAction() {
         createRoomButton.addAction(
             UIAction { [weak self] _ in
-                self?.showCreateRoomLoading()
+                //self?.showCreateRoomLoading()
+                self?.showStartTutorial()
             },
             for: .touchUpInside
         )
@@ -155,13 +157,28 @@ final class OnboardingViewController: UIViewController {
         let roomActionRepository = DIContainer.shared.resolve(RoomActionRepositoryProtocol.self)
         guard let navigationController else { return }
 
-        gameNavigationController = GameNavigationController(
+        gameNavigationController = GeneralGameNavigationController(
             navigationController: navigationController,
             gameStateRepository: gameStateRepository,
             roomActionRepository: roomActionRepository,
             roomNumber: roomNumber
         )
 
+        gameNavigationController?.setConfiguration()
+    }
+    
+    private func navigateToTutorial() {
+        if let nickname = nickNamePanel.text, !nickname.isEmpty {
+            viewModel?.setNickname(with: nickname)
+        }
+        viewModel?.saveNickname()
+        
+        guard let navigationController else { return }
+        gameNavigationController = AIGameNavigationController(
+            navigationController: navigationController,
+            aiImageURL: viewModel?.randomAvatarURL() ?? []
+        )
+        
         gameNavigationController?.setConfiguration()
     }
 
@@ -255,6 +272,16 @@ extension OnboardingViewController {
             },
             errorCompletion: { [weak self] error in
                 self?.showRoomFailedAlert(error)
+            }
+        )
+        presentAlert(alert)
+    }
+    
+    private func showStartTutorial() {
+        let alert = LoadingAlertController(
+            progressText: .startTutorial,
+            loadAction: { [weak self] in
+                self?.navigateToTutorial()
             }
         )
         presentAlert(alert)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewController.swift
@@ -100,8 +100,7 @@ final class OnboardingViewController: UIViewController {
     private func setAction() {
         createRoomButton.addAction(
             UIAction { [weak self] _ in
-                //self?.showCreateRoomLoading()
-                self?.showStartTutorial()
+                self?.showCreateRoomLoading()
             },
             for: .touchUpInside
         )

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -1,3 +1,4 @@
+import ASEntity
 import ASMusicKit
 import ASRepositoryProtocol
 import Foundation
@@ -30,6 +31,16 @@ final class OnboardingViewModel: @unchecked Sendable {
 
     func setNickname(with nickname: String) {
         self.nickname = nickname
+    }
+    
+    func randomAvatarURL() -> [URL?] {
+        [avatars.randomElement(), avatars.randomElement()]
+    }
+    
+    func saveNickname() {
+        saveDataRepository.savePlayer(
+            tutorialPlayer: Player(id: "2", avatarUrl: selectedAvatar, nickname: nickname)
+        )
     }
 
     func refreshAvatars() {

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Onboarding/OnboardingViewModel.swift
@@ -5,6 +5,7 @@ import Foundation
 final class OnboardingViewModel: @unchecked Sendable {
     private var roomActionRepository: RoomActionRepositoryProtocol
     private var dataDownloadRepository: DataDownloadRepositoryProtocol
+    private var saveDataRepository: SaveDataRepositoryProtocol
     private var avatars: [URL] = []
     private var selectedAvatar: URL?
 
@@ -14,12 +15,14 @@ final class OnboardingViewModel: @unchecked Sendable {
 
     init(roomActionRepository: RoomActionRepositoryProtocol,
          dataDownloadRepository: DataDownloadRepositoryProtocol,
+         saveDataRepository: SaveDataRepositoryProtocol,
          avatars: [URL],
          selectedAvatar: URL?,
          avatarData: Data?
     ) {
         self.roomActionRepository = roomActionRepository
         self.dataDownloadRepository = dataDownloadRepository
+        self.saveDataRepository = saveDataRepository
         self.avatars = avatars
         self.selectedAvatar = selectedAvatar
         self.avatarData = avatarData


### PR DESCRIPTION
## 관련 이슈

- #38 

## 완료 및 수정 내역
 - [x] 튜토리얼 앱 설명이후 사용될 로비화면 구현

## 테스트 방법 (선택)

## 리뷰 노트
어떤 모드의 튜토리얼인지 알려줄려면 로비뷰가 필요하다고 판단해서 튜토리얼 로비뷰 먼저 구현했습니다.

- 튜토리얼에 사용될 닉네임 + 캐릭터는 로컬에 저장한 뒤 불러오는 방식으로 진행했습니다.
- `@Published`를 활용하기 위해 상속하는 형태로 설계했습니다.

## 스크린샷(선택)
<img width=280, src=https://github.com/user-attachments/assets/77f56988-69ea-42d1-93ad-1cd6088de9ed>

- 회의내용을 참고해서 하단 버튼 워딩을 튜토리얼 시작에서 게임 시작으로 변경했습니다.
