### PR TITLE
[Hotfix] 로비 화면 캐러셀 잔상문제 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyView.swift
@@ -8,7 +8,7 @@ struct LobbyView: View {
         VStack {
             ScrollView(.horizontal) {
                 HStack(alignment: .top, spacing: 16) {
-                    ForEach(0 ..< viewModel.playerMaxCount) { index in
+                    ForEach(0..<viewModel.playerMaxCount) { index in
                         if index < viewModel.players.count {
                             let player = viewModel.players[index]
                             ProfileView(

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Lobby/LobbyViewController.swift
@@ -4,7 +4,7 @@ import SwiftUI
 final class LobbyViewController: UIViewController {
     private let inviteButton = ASButton()
     private let startButton = ASButton()
-    private var lobbyView = UIViewController()
+    private lazy var lobbyUIHostingController = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
     private let viewmodel: LobbyViewModel
     private var cancellables: Set<AnyCancellable> = []
 
@@ -20,7 +20,8 @@ final class LobbyViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        lobbyView = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
+
+        lobbyUIHostingController.view.isHidden = false
     }
 
     override func viewDidLoad() {
@@ -33,7 +34,7 @@ final class LobbyViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        lobbyView.view = nil
+        lobbyUIHostingController.view.isHidden = true
     }
 
     private func bindToComponents() {
@@ -73,9 +74,7 @@ final class LobbyViewController: UIViewController {
             backgroundColor: .asMint
         )
 
-        lobbyView = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
-
-        view.addSubview(lobbyView.view)
+        view.addSubview(lobbyUIHostingController.view)
         view.addSubview(startButton)
         view.addSubview(inviteButton)
     }
@@ -104,13 +103,13 @@ final class LobbyViewController: UIViewController {
     private func setupLayout() {
         inviteButton.translatesAutoresizingMaskIntoConstraints = false
         startButton.translatesAutoresizingMaskIntoConstraints = false
-        lobbyView.view.translatesAutoresizingMaskIntoConstraints = false
+        lobbyUIHostingController.view.translatesAutoresizingMaskIntoConstraints = false
         
         NSLayoutConstraint.activate([
-            lobbyView.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            lobbyView.view.bottomAnchor.constraint(equalTo: inviteButton.topAnchor, constant: -20),
-            lobbyView.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            lobbyView.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            lobbyUIHostingController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            lobbyUIHostingController.view.bottomAnchor.constraint(equalTo: inviteButton.topAnchor, constant: -20),
+            lobbyUIHostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            lobbyUIHostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
 
             inviteButton.bottomAnchor.constraint(equalTo: startButton.topAnchor, constant: -25),
             inviteButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -3,6 +3,9 @@ import Combine
 import SwiftUI
 
 class HummingResultViewController: UIViewController {
+    deinit {
+        Logger.debug("HummingResultViewController deinit")
+    }
     private let answerView = MusicPanelView()
     private let resultTableView = UITableView()
     private let nextButton = ASButton()
@@ -137,10 +140,9 @@ class HummingResultViewController: UIViewController {
             .combineLatest(viewModel.$result, viewModel.$isHost)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] phase, result, isHost in
-                guard let self else { return }
-                addDataSource(phase, result: result)
+                self?.addDataSource(phase, result: result)
                 if result.answer != nil, isHost {
-                    changeButton(phase)
+                    self?.changeButton(phase)
                 }
             }
             .store(in: &cancellables)
@@ -148,16 +150,15 @@ class HummingResultViewController: UIViewController {
         viewModel.$canEndGame
             .receive(on: DispatchQueue.main)
             .sink { [weak self] canEndGame in
-                guard let self else { return }
                 if canEndGame {
-                    nextButton.updateButton(.complete)
-                    nextButton.isEnabled = true
-                    nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
-                    nextButton.addAction(UIAction { _ in
-                        self.showLobbyLoading()
+                    self?.nextButton.updateButton(.complete)
+                    self?.nextButton.isEnabled = true
+                    self?.nextButton.removeTarget(nil, action: nil, for: .touchUpInside)
+                    self?.nextButton.addAction(UIAction { _ in
+                        self?.showLobbyLoading()
                     }, for: .touchUpInside)
                 } else {
-                    nextButton.updateButton(.disabled)
+                    self?.nextButton.updateButton(.disabled)
                 }
             }
             .store(in: &cancellables)

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewController.swift
@@ -30,7 +30,9 @@ class HummingResultViewController: UIViewController {
         viewModel?.bindResult()
     }
 
-    override func viewDidDisappear(_: Bool) {
+    override func viewDidDisappear(_ animation: Bool) {
+        super.viewDidDisappear(animation)
+        
         viewModel?.cancelSubscriptions()
     }
 


### PR DESCRIPTION
## 관련 이슈
- #53 

## 완료 및 수정 내역

 - [x] 게임이 종료된 뒤 다시 로비뷰로 갔을 때 LobbyView전체가 보이지 않는 문제 해결
 - [x] 온보딩 뷰로 넘어가면 잔상 남는 문제 해결

## 리뷰 노트
변수명을 변경하면서 변경사항이 많아보이지만 사실 isHidden이 메인 변경 사항입니다.

### 히스토리 및 작업 흐름

기존 문제:
로비뷰에서 모드를 스크롤하고 온보딩 뷰로 넘어가면 잔상이 남았음.

건우님께서 개선하신 코드1
- #16 
```swift
final class LobbyViewController: UIViewController {    
     override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated)
        lobbyUIHostingController.view = nil
    }
}
```

문제: 게임이 다 끝나고 다시 로비로 돌아왔을 때 LobbyView 전체가 보이지 않는 문제 발생

건우님께서 개선하신 코드2
- #29
```swift
final class LobbyViewController: UIViewController {    
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        lobbyUIHostingController = UIHostingController(rootView: LobbyView(viewModel: viewmodel))
    }
    
    override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated)
        lobbyUIHostingController.view = nil
    }
}
```

문제: 온보딩 뷰로 넘어가면 잔상남는 문제 발생. (가장 처음에 발생했던 문제 다시 발현)

결론

viewWillAppear에서 초기화하지 않으면

→ 게임이 종료된 뒤 다시 로비뷰로 갔을 때 LobbyView전체가 보이지 않음

viewWillAppear에서 초기화하면

→ 게임 시작 전 모드 가로 스크롤 후 온보딩뷰로 돌아갔을 때 잔상이 남음

---

### 시도 1: nil이 아니라 아예 부모뷰에서 제거하기

nil로 만드는 것이 아니라 아예 부모뷰에서 제거하는 방법을 시도. 이렇게되면 뷰 계층에서 바로 없어질 것이라고 판단.

```swift
final class LobbyViewController: UIViewController {
    override func viewWillAppear(_ animated: Bool) {
        super.viewWillAppear(animated)
        view.addSubview(lobbyUIHostingController.view)
        // 이후에 레이아웃 작업을 해줘야함
    }
    
    override func viewWillDisappear(_ animated: Bool) {
        super.viewWillDisappear(animated)
        lobbyUIHostingController.view.removeFromSuperview()
    }
}
```

원하는대로 잘 제거가 되었으나, 게임 완료 후 돌아왔을 때 lobbyUIHostingController.view의 레이아웃을 다시 잡아줘야하는 번거로움이 있다고 판단함. 실제로 레이아웃을 잡아주지 않으면 아래와 같이 깨지는 문제 발생.

| 뷰 계층 구조 | 시뮬레이터 |
| -- | -- |
| <img width="715" src="https://github.com/user-attachments/assets/7ee85934-b489-489f-8436-040e9e51d530" /> | <img width="415" src="https://github.com/user-attachments/assets/56d8782e-d9a6-45d3-9f26-c9ad0109e245" />

레이아웃을 한 번만 잡는 방법이 없을까 고민하다가 Hidden을 사용하면 레이아웃이 유지된다는 점을 고려해 isHidden 프로퍼티를 활용.

## 스크린샷(선택)

- 온보딩으로 돌아갔을 때

https://github.com/user-attachments/assets/c59b03c0-d97e-47b4-ac15-2d567f25b4df

- 게임이 끝나고 로비뷰로 돌아왔을 때

https://github.com/user-attachments/assets/7d755856-52ec-492d-9d48-03aa3a3958ae
