### PR TITLE
[Hotfix] 결과화면에서 로비로 이동했을 때 노래가 플레이되는 문제

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Result/HummingResultViewModel.swift
@@ -64,6 +64,7 @@ final class HummingResultViewModel: @unchecked Sendable {
     /// 변경 후 바로 오디오 재생 시작
     /// submit -> answer의 경우에는 recordOrder만 변경
     private func updateResultPhase() {
+        guard !canEndGame else { return }
         Task {
             switch resultPhase {
                 case .answer:


### PR DESCRIPTION
## 관련 이슈

- #55 

## 완료 및 수정 내역

 - [x] 완료된 경우 로직을 타지 않도록 개선

## 테스트 방법 (선택)

## 리뷰 노트

## 스크린샷(선택)

영상 플레이 시 소리를 키워주세요 😄

- 수정 전


https://github.com/user-attachments/assets/3be59036-01cf-4159-b703-ab578fd39deb


- 수정 후 (앞부분이 잘렸습니다..! 결과화면에서 로비뷰로 돌아온 직후입니다)

https://github.com/user-attachments/assets/6b44d9aa-cadf-4a66-b2ad-c52a171e53e9

