### PR TITLE
[Hotfix] 정답 제출 네비게이션 타이틀, 결과확인에서 서울의 봄 잘못된 결과 이슈 해결

### DIFF
--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Result/HummingResultTutorialViewModel.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/Result/HummingResultTutorialViewModel.swift
@@ -201,11 +201,17 @@ final class HummingResultTutorialViewModel: ObservableObject {
                 music: TutorialData.loser
             )
         }
-        let music = try? await ASMusicAPI().search(for: result.bestClassification).first
-        return ASEntity.Answer(
-            player: player,
-            music: music
-        )
+        let musicTitle = result.bestClassification
+        switch musicTitle {
+        case "Loser":
+            return ASEntity.Answer(player: player, music: TutorialData.loser)
+        case "Super Shy":
+            return ASEntity.Answer(player: player, music: TutorialData.superShy)
+        case "Moon of Seoul":
+            return ASEntity.Answer(player: player, music: TutorialData.theMoonOfSeoul)
+        default:
+            return ASEntity.Answer(player: player, music: TutorialData.loser)
+        }
     }
 }
 

--- a/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
+++ b/alsongDalsong/alsongDalsong/alsongDalsong/Sources/Views/Tutorial/SubmitAnswer/SubmitAnswerTutorialViewController.swift
@@ -65,6 +65,8 @@ final class SubmitAnswerTutorialViewController: UIViewController {
     }
     
     private func setupUI() {
+        title = "정답 선택"
+        
         selectAnswerButton.setConfiguration(text: String(localized: "정답 선택"), backgroundColor: .asLightSky)
         submitButton.setConfiguration(text: String(localized: "정답 제출"), backgroundColor: .asLightGray)
         submitButton.updateButton(.disabled)


### PR DESCRIPTION
## 관련 이슈

- #82 

## 완료 및 수정 내역

 - [x] 결과확인에서 서울의 봄 잘못된 결과 이슈 해결
 - [x] 정답 제출 네비게이션 타이틀이 없던 문제 해결
